### PR TITLE
Refresh agent guide with current architecture details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,302 +1,171 @@
-# AGENTS.md — Code Navigation & Improve Plan (for LLMs only)
+# AGENTS.md — Code Navigation & Current Architecture
 
 > Base repo: `https://github.com/tractusevents/Tractus.HtmlToNdi`
-> Purpose: help coding agents quickly navigate, modify, and extend **Tractus.HtmlToNdi** into a headless, multi-feed, smooth-pacing WebGL2/WebGPU → **NDI 6+** renderer on Windows with alpha.
-> Source of truth for this doc: the user-supplied architecture brief summarizing the repo (merged here). 
+> Purpose: help coding agents quickly understand and extend **Tractus.HtmlToNdi**, a Windows-focused headless Chromium → NDI bridge with HTTP control and limited KVM.
 
 ---
 
-## 0) Ground truth (what the app does today)
+## 0) Ground truth — what ships today
 
-* Wraps **Chromium (CefSharp OffScreen)** and an **NDI .NET wrapper** to publish a web page (video+audio) as an NDI source. Default viewport: **1920×1080 @ 60 fps**. Alpha is preserved if the page is transparent. HTTP control API is included. 
-* Core pieces: off-screen Chromium with transparency; NDI sender (RGBA frames, optional audio); minimal ASP.NET Core API (default port **9999**); optional NDI **KVM** support (mouse move/down/up handled). 
-* CLI flags (from README/usage): `--ndiname`, `--width`, `--height`, `--url`, `--port`. 
-* Key limits today: frames sent as **RGBA** (byte-swizzle overhead from BGRA likely); **no H.264** codecs in Chromium build (YouTube etc. won’t work); 60 fps cap; single browser instance per process; fixed output size; audio passed through without mixing. 
+* `Program.cs` bootstraps Serilog logging (`AppManagement.Initialize`), parses CLI flags (`--ndiname`, `--port`, `--url`, `--w`, `--h`), and spins up three subsystems: CefSharp OffScreen browser, NDI sender, and ASP.NET Core minimal API server.
+* CefSharp is launched off-thread via `AsyncContext.Run`. The browser is created windowless with audio enabled, fixed viewport, and a watchdog thread that invalidates frames if Chromium goes idle.
+* Video frames are forwarded straight from the BGRA paint buffer to NDI using `NDIlib.send_send_video_v2`. Audio frames are captured through a custom `IAudioHandler` and forwarded via `NDIlib.send_send_audio_v2`.
+* HTTP API (Swagger enabled) exposes `/seturl`, `/scroll/{increment}`, `/click/{x}/{y}`, `/keystroke`, `/type/{text}`, and `/refresh` for remote control. All routes operate on the single global `CefWrapper` instance.
+* KVM metadata from NDI receivers is polled in a background thread. Mouse move (`opcode 0x03`) updates the cached normalized coordinates; mouse down (`opcode 0x04`) triggers a left-click at the cached position.
+* Default behavior: 1920×1080 @ 60 fps progressive frames, transparent backgrounds preserved, audio passthrough.
 
 ---
 
 ## 1) Repository map (fast navigation)
 
-> Use these paths/keywords to index the codebase. Adapt to actual filenames with a quick directory scan.
-
 ```
-/Chromium/                 # CefSharp OffScreen host & handlers (render/audio/input/helpers)
-/Models/                   # HTTP API request/response DTOs (e.g., SetUrl)
-/Properties/               # Assembly info, resources
-AppManagement.cs           # Bootstrap/config helpers (args/appsettings wiring)
-/* Program.cs */           # Entry point: args → NDI + Chromium → HTTP API → run/shutdown
-Tractus.HtmlToNdi.csproj   # NuGet refs (CefSharp OffScreen, NDI wrapper), target framework, native copies
-Tractus.HtmlToNdi.http     # HTTP request examples (API smoke tests)
-appsettings*.json          # Optional config (logging, HTTP, etc.)
-README.md                  # Usage/flags/limits
+/Chromium/                 # CefSharp OffScreen helpers (browser wrapper, audio handler, sync context)
+/Models/                   # HTTP DTOs shared by minimal API
+AppManagement.cs           # Logging bootstrap, filesystem helpers
+Program.cs                 # Entry point: CLI → Chromium + NDI + HTTP API + KVM
+Tractus.HtmlToNdi.csproj   # Target framework/net6.0-windows, NuGet packages (CefSharp, NDI)
+Tractus.HtmlToNdi.http     # Ready-to-send HTTP API examples
+appsettings*.json          # ASP.NET Core configuration defaults
+README.md                  # Usage, CLI parameters, known limitations
 ```
 
-> Tip: enumerate `/Chromium` and `/Models` first; they contain the primary extension points.
+Tip: the runtime state (browser + NDI) is controlled exclusively through `Program.browserWrapper`; there is no dependency injection beyond minimal API static capture.
 
 ---
 
-## 2) High-level architecture & data flow (confirmed)
+## 2) High-level flow
 
 ```
-[Program.cs]
-  ├─ Parse CLI (--ndiname/--width/--height/--port/--url)
-  ├─ Init NDI sender (name, RGBA WxH, ~60 fps)
-  ├─ Init CefSharp OffScreen browser (windowless+transparent, WxH, cap fps=60)
-  ├─ Start ASP.NET Core minimal API (e.g., POST /seturl, /refresh)
-  └─ Run until shutdown; dispose NDI + Chromium, stop KVM thread
-         │
-         ▼
-[Chromium wrapper (OffScreen)]
-  ├─ Create ChromiumWebBrowser (transparent background)
-  ├─ Frame capture (BGRA → RGBA copy if needed) → NDI video frame
-  ├─ (Optional) IAudioHandler → NDI audio frame
-  └─ Control surface: SetUrl(), Refresh(), Click(x,y) for KVM
-         │
-         ▼
-[NDI .NET wrapper]
-  ├─ Create sender (metadata can advertise KVM)
-  ├─ Send video frames (RGBA) and PCM audio
-  └─ Capture NDI metadata for KVM; inject to Chromium
+[Main]
+  ├─ Call AppManagement.Initialize(args) → Serilog + file logging
+  ├─ Prompt/parse CLI → ndiName, port, url, width, height
+  ├─ AsyncContext.Run → Cef.Initialize + create CefWrapper(width, height, url)
+  │      └─ CefWrapper.InitializeWrapperAsync() registers paint callback & audio handler
+  ├─ Build WebApplication → map HTTP routes → enable Swagger
+  ├─ Create NDI sender (NDIlib.send_create)
+  │      └─ Advertise KVM capability via metadata
+  ├─ Start KVM metadata polling thread (NDIlib.send_capture)
+  └─ app.Run() → blocks until shutdown, then dispose browser and delete cache dir
 ```
 
-All above is explicitly described or implied in the architecture brief and README. 
+The browser → NDI path is synchronous on the Cef paint callback: every frame triggers `send_send_video_v2`. Audio is pulled on Cef's audio thread and interleaved before hitting NDI.
 
 ---
 
-## 3) File-by-file guidance (what to extend where)
+## 3) Chromium wrapper specifics
 
-> Names/locations reflect the merged architecture brief. Confirm with a quick `grep` (see §5).
-
-### 3.1 `Program.cs` — orchestration & hosting
-
-**Responsibilities**
-
-* Parses CLI → sets up logging (Serilog) → creates **NDI sender** → creates **Chromium OffScreen** browser → starts **HTTP API** → runs until shutdown; cleanly disposes NDI/browser; joins **KVM** thread if enabled. 
-
-**Extend here**
-
-* Add new API routes: `/refresh`, `/size`, `/fps`, `/eval`, `/stats`. 
-* Insert **FramePacer** hookup (consumer loop) if send cadence is coordinated here.
-* Wire **KVM enable/disable** by CLI flag; ensure thread lifetime is managed.
-
-### 3.2 `AppManagement.cs` — bootstrap/helpers
-
-**Responsibilities**
-
-* Centralizes argument parsing & defaults (name = “HTML5”, 1920×1080, port 9999) and possibly Cef/NDI init scaffolding. 
-
-**Extend here**
-
-* Add CLI for **fractional fps** (`--fps-n`, `--fps-d`), **pixel format** (`--pixel=bgra|rgba`), **HDR** toggle (NDI 6).
-* Inject Chromium switches for **WebGL2**/**WebGPU** when you move to accelerated paths.
-
-### 3.3 `/Chromium/*` — CefSharp OffScreen host
-
-**Responsibilities**
-
-* Creates **ChromiumWebBrowser** (windowless, transparent), caps internal redraw to **60 fps** (`BrowserSettings.WindowlessFrameRate`). 
-* Captures frames (BGRA buffer) on paint or via screenshot API; converts to **RGBA** (current sender path) and forwards to NDI. 
-* Implements **IAudioHandler** (optional) → forward PCM to NDI; implements control methods: `SetUrl`, `Refresh`, `Click(x,y)` (for NDI KVM). 
-
-**Extend here**
-
-* Add producer hook to push frames into **FramePacer** queue.
-* Provide **BGRA** → NDI direct path if wrapper supports it (avoid swizzle).
-* Add **EvaluateScriptAsync** bridge for `/eval`.
-
-### 3.4 `/Models/*` — HTTP DTOs
-
-* Expect a `SetUrl`/`GoToUrlModel` with `Url` string for `POST /seturl`; extend with DTOs for `/size`, `/fps`, `/eval`. 
-
-### 3.5 `Tractus.HtmlToNdi.csproj`
-
-* NuGet: **CefSharp.OffScreen**, **CefSharp.Common**, **NDI .NET wrapper** (“NdiLibDotNetAdvanced”). Ensure native NDI DLL copy rules. 
-* TargetFramework: .NET 6/7/8 (verify). Add build constants for **x64**, optional **HDR** builds.
-
-### 3.6 `Tractus.HtmlToNdi.http`
-
-* Contains ready-to-run `POST /seturl` etc. Extend with `/refresh`, `/size`, `/fps`, `/eval`, `/stats`. 
+* `CefWrapper` stores width/height/url and owns the `ChromiumWebBrowser` instance. Audio is always on; `ToggleAudioMute` is called after initial load to unmute.
+* `InitializeWrapperAsync` waits for the initial load, caps `WindowlessFrameRate` to 60, subscribes to `Paint`, and starts a watchdog thread that invalidates once per second to avoid stalls.
+* `OnBrowserPaint` sets `frame_rate_N=60`/`frame_rate_D=1`, `FourCC=BGRA`, and forwards Chromium's GPU-buffer handle directly to NDI. No pixel swizzle occurs—Chromium already exposes BGRA and the NDI sender accepts BGRA frames.
+* Input helpers: `ScrollBy` issues a mouse wheel event, `Click` performs left-button down/up with a 100 ms pause, `SendKeystrokes` iterates characters sending `KeyDown` events only, and `RefreshPage` reloads the current tab.
 
 ---
 
-## 4) NDI KVM (implemented subset; extendable)
+## 4) HTTP API surface (2024-10 build)
 
-* Sender advertises `<ndi_capabilities ntk_kvm="true" />`; a **background thread** uses `NDIlib.send_capture(...)` to receive metadata. Data is XML `<ndi_kvm ...>` with base64 payload. Handled opcodes:
+Route | Method | Payload | Effect
+---|---|---|---
+`/seturl` | POST | `{ "url": "https://..." }` | Calls `CefWrapper.SetUrl`
+`/scroll/{increment}` | GET | path int | Sends a wheel event (positive=scroll down)
+`/click/{x}/{y}` | GET | path ints | Issues a left click at pixel coordinates
+`/keystroke` | POST | `{ "toSend": "..." }` | Iterates characters via `SendKeystrokes`
+`/type/{toType}` | GET | path string | Convenience wrapper around `/keystroke`
+`/refresh` | GET | none | Reloads the page
 
-  * `0x03` **mouse move** → store normalized (x,y) in [0..1].
-  * `0x04` **mouse left down** → scale to pixels → `Click(x,y)` (down).
-  * `0x07` **mouse left up** → scale to pixels → `Click(x,y)` (up).
-    Extend with keyboard, right-click, scroll by decoding more opcodes and mapping to Cef input. 
-
----
-
-## 5) Quick “grep map” (drop-in queries)
-
-Search these strings to jump to relevant code:
-
-**Chromium setup**
-`WindowlessRenderingEnabled` · `SetAsWindowless` · `BrowserSettings.WindowlessFrameRate` · `ChromiumWebBrowser(`
-
-**Frame capture paths**
-`OnPaint(` · `IRenderHandler` · `ScreenshotAsync` · `GetBitmapAsync` · `BGRA` · `RGBA` · `PixelFormat`
-
-**NDI video/audio**
-`NDIlib_send_create` · `NDIlib.send_` · `VideoFrame` · `FourCC` · `frame_rate_N` · `frame_rate_D` · `send_audio`
-
-**HTTP API**
-`WebApplication.CreateBuilder` · `MapPost("/seturl"` · `Refresh()` · `GoToUrlModel`
-
-**KVM**
-`ndi_kvm` · `base64` · `0x03` · `0x04` · `0x07` · `Click(`
-
-(Entities and flow confirmed in the brief/README.) 
+Swagger UI is available at `/swagger` on the configured port (default 9999). All endpoints are unauthenticated and operate on the singleton browser.
 
 ---
 
-## 6) Known constraints & facts (repo-stated)
+## 5) NDI pipeline
 
-* **Defaults**: 1920×1080; **60 fps**; alpha honored when page is transparent; audio passthrough. 
-* **Limits**: RGBA send path (BGRA→RGBA conversion cost); no H.264 codecs (YouTube likely won’t play); 60 fps cap; one browser/NDI per process; fixed output size. 
-
----
-
-## 7) Extension plan (prioritized tasks for agents)
-
-> Keep changes additive; gate behind CLI flags where possible.
-
-### A. Stable 29.97p (or 59.94p) pacing
-
-* Add `--fps-n`/`--fps-d` (e.g., **30000/1001** for 29.97).
-* Implement **FramePacer** (SPSC ring). Producer = Chromium frames; Consumer = precise timer at target fps; on tick: **send newest**, else **repeat last**. (Alpha preserved.)
-
-**Sender wiring (C# snippet)**
-
-```csharp
-// When filling the NDI video frame:
-video.frame_rate_N = FpsNumerator;   // e.g., 30000
-video.frame_rate_D = FpsDenominator; // e.g., 1001
-// frame_format_type = progressive; FourCC = BGRA or RGBA per wrapper support.
-```
-
-**Consumer loop (C# skeleton)**
-
-```csharp
-var ticksPerSec = (double)Stopwatch.Frequency;
-var interval = 1001.0 / 30000.0; // 29.97p
-var next = Stopwatch.GetTimestamp();
-Frame? last = null;
-while (running) {
-    if (ring.TryPop(out var f)) last = f;   // drain to freshest
-    if (last != null) NdiSend(last);
-    next += (long)(interval * ticksPerSec);
-    var sleep = next - Stopwatch.GetTimestamp();
-    if (sleep > 0) Thread.Sleep(TimeSpan.FromSeconds(sleep / ticksPerSec));
-    else next = Stopwatch.GetTimestamp();  // catch up
-}
-```
-
-### B. Multi-instance / multi-output
-
-* Introduce `BrowserSession` + `NdiSession`; manage a collection keyed by `--instance`.
-* Option 1: multiple sessions in one process (thread per session). Option 2: supervisor process spawning child processes (simpler isolation).
-
-### C. Adjustable resolution & live resize
-
-* Add `POST /size { width, height }` → recreate Chromium + NDI (expect one-time stutter).
-* Optional: scale or letterbox via CSS.
-
-### D. WebGL2/WebGPU toggles
-
-* Add `--webgl2 on`, `--webgpu on`; inject Chromium switches in Cef settings. Use WebGL2 baseline first; gate WebGPU behind flag.
-
-### E. Pixel formats & HDR (NDI 6)
-
-* Add `--pixel=bgra|rgba`; prefer **BGRA→NDI** direct if supported by wrapper to avoid copy.
-* Gate HDR/10-bit behind `--hdr on` (if the chosen NDI wrapper supports it).
-
-### F. API surface
-
-* `POST /refresh` → reload
-* `POST /eval { script }` → JS in page
-* `GET /stats` → fps, queue depth, drops/repeats
-* `POST /screenshot` → PNG (with alpha)
-* `POST /fps { n, d }` → set fractional fps at runtime (reinit pacer)
-
-All extensions are compatible with the current architecture. 
+* Creation: `Program.NdiSenderPtr` is initialized once with `NDIlib.send_create` using the CLI-specified source name.
+* Video: `CefWrapper.OnBrowserPaint` constructs an `NDIlib.video_frame_v2_t` (BGRA progressive, stride = width × 4) and sends with `NDIlib.send_send_video_v2`.
+* Audio: `CustomAudioHandler` allocates an interleaved float buffer sized for one second of audio. For each audio packet, channel planes are copied into the interleaved buffer and transmitted via `NDIlib.send_send_audio_v2`.
+* Metadata/KVM: After creation, the app publishes `<ndi_capabilities ntk_kvm="true" />`. A dedicated thread blocks on `NDIlib.send_capture`, inspecting metadata frames for `<ndi_kvm ...>` commands.
 
 ---
 
-## 8) Minimal route/example stubs (paste then align to actual types)
+## 6) KVM handling details
 
-**POST /seturl**
+* Only mouse metadata opcodes are processed. `0x03` updates `x`/`y` normalized floats (0–1). `0x04` triggers a left-click using the cached coordinates scaled by the configured width/height. `0x07` (left-up) is recognized but intentionally left empty—`Click` handles both down/up.
+* There is no handling for drag, right/middle buttons, keyboard injection, or scroll via KVM metadata; the HTTP API must be used for those interactions.
+* The metadata polling thread runs until shutdown; `running` flag flips after `app.Run()` completes, and the thread is joined before exiting.
 
-```csharp
-app.MapPost("/seturl", async (GoToUrlModel req, BrowserWrapper browser) =>
-{
-    await browser.SetUrlAsync(req.Url);
-    return Results.Ok();
-});
-```
+---
 
-(Existing behavior; confirm model name and DI style.) 
+## 7) Known constraints & quirks
 
-**KVM click injection (concept)**
+1. **Codec support**: Chromium build lacks proprietary codecs (H.264), so DRM/YouTube playback fails.
+2. **Frame pacing**: Browser refresh rate and NDI `frame_rate_N/D` are hard-coded to 60/1; no dynamic adjustment or fractional frame rates.
+3. **Single instance**: Global statics (`Program.browserWrapper`, `Program.NdiSenderPtr`) assume one browser/sender per process.
+4. **Input gaps**: No keyboard key-up events, no text composition, and no error handling for invalid coordinates.
+5. **Resource cleanup**: Temporary Cef cache folder is deleted on shutdown, but abrupt termination may leave residue.
+6. **Security**: HTTP endpoints have no authentication/authorization; exposure to untrusted networks is unsafe.
 
-```csharp
-// From KVM thread after decoding 0x04/0x07 and scaling normalized coords:
-browser.Click(screenX, screenY); // already present; extend with move/keys
-```
+---
 
-(Subset already implemented: move, left down, left up.) 
+## 8) Prioritized extension roadmap
+
+1. **Add authentication & TLS to HTTP API** — prevent remote misuse and enable deployment beyond trusted LANs.
+2. **Expose dynamic frame rate & resolution controls** — allow runtime `/size` or `/fps` adjustments with safe reinitialization of Cef/NDI.
+3. **Improve KVM fidelity** — handle drag (mouse down/up separation), right-click, keyboard metadata, and pointer smoothing.
+4. **Robust input API** — add key-up events, text composition, and error responses for invalid requests.
+5. **Observability** — implement `/stats` endpoint reporting render cadence, dropped frames, audio state, and cache health.
+6. **Codec/WebGL enhancements** — optional Chromium flags for WebGL2/WebGPU and exploring BGRA → NDI zero-copy improvements.
 
 ---
 
 ## 9) Validation checklist (post-change)
 
-* **Alpha:** load transparent test page → verify alpha in NDI receiver (checkerboard). 
-* **Pacing:** measure output inter-frame ~**33.366 ms** (29.97p) or **16.683 ms** (59.94p) over ≥10 minutes; report drops/repeats.
-* **Stress:** heavy WebGL2 animation: queue depth 1–4, no visible stutter for 10 min.
-* **Audio:** PCM from page reaches NDI; no drift vs video. 
-* **API:** `/seturl`, `/refresh`, `/size`, `/fps`, `/stats` work and are documented in `.http`.
+* ✅ Transparent test page → verify alpha in NDI receiver.
+* ✅ Motion stress (WebGL animation) → monitor frame cadence ~16.6 ms for 60 fps.
+* ✅ Audio playback (stereo) → confirm levels in receiver, no drift.
+* ✅ HTTP API → exercise every route via `Tractus.HtmlToNdi.http` or Swagger.
+* ✅ KVM metadata → confirm pointer click arrives when interacting from NDI Studio Monitor.
 
 ---
 
-## 10) Appendices for agents to fill after first scan
+## 10) Appendices
 
-> Do a quick repo crawl and complete these summaries for faster future edits.
+### /Chromium index
 
-### /Chromium index (fill)
+* `CefWrapper.cs` — owns `ChromiumWebBrowser`; handles initialization, render watchdog, paint-to-NDI forwarding, and user input helpers (`SetUrl`, `ScrollBy`, `Click`, `SendKeystrokes`, `RefreshPage`).
+* `CustomAudioHandler.cs` — `IAudioHandler` implementation converting CefSharp planar float buffers into interleaved floats for NDI audio frames.
+* `AsyncContext.cs` — helper to run async Cef initialization on a dedicated single-threaded synchronization context.
+* `SingleThreadSynchronizationContext.cs` — blocking queue-based context used by `AsyncContext` to keep CefSharp thread affinity.
 
-* `Chromium/<file>.cs` — classes: … — responsibilities: … — key methods: … — **signals → NDI**: …
+### /Models index
 
-### /Models index (fill)
+* `GoToUrlModel.cs` — DTO with `string Url`; consumed by `/seturl` POST.
+* `SendKeystrokeModel` (same file) — DTO with `string ToSend`; consumed by `/keystroke` POST and indirectly by `/type/{toType}`.
 
-* `Models/<file>.cs` — DTO: … (properties …) — used by route …
+### NDI path summary
 
-### NDI path
-
-* NDI wrapper type(s): … — creation: … — send call(s): … — pixel format: … — **frame_rate_N/D** hookup: …
+* **Creation**: `Program.NdiSenderPtr = NDIlib.send_create` using UTF-8 encoded name.
+* **Video send**: `CefWrapper.OnBrowserPaint` builds `NDIlib.video_frame_v2_t` with BGRA buffer handle and invokes `NDIlib.send_send_video_v2`.
+* **Audio send**: `CustomAudioHandler.OnAudioStreamPacket` copies samples into `audio_frame_v2_t` and calls `NDIlib.send_send_audio_v2`.
+* **Metadata**: Capabilities advertised via `NDIlib.send_add_connection_metadata`; KVM commands retrieved through `NDIlib.send_capture` loop in `Program`.
 
 ### Known TODOs in code
 
-* …
+* `CefWrapper.Dispose` still contains commented TODOs regarding unmanaged cleanup; currently acceptable but consider auditing.
+* KVM handler ignores opcode `0x07` (mouse up) and lacks drag/scroll implementations.
+* Keyboard injection uses only key-down events—no key-up or modifier support, which may break complex input.
 
 ---
 
-## 11) Notes for LLM agents
+## 11) Notes for future agents
 
-* Keep edits **surgical**; preserve existing behavior unless gated by new CLI flags.
-* Prefer **BGRA direct send** if possible to eliminate RGBA conversion.
-* Treat WebGPU as **opt-in experimental**; keep WebGL2 as the default baseline.
-* Always add **plain-English comments** near timing/pacing code.
-* Log queue depth, send cadence, and drops/repeats; expose via `/stats`.
+* Keep edits focused; touch only relevant files and respect the single-instance design unless intentionally refactoring.
+* Prefer enhancing existing helpers (`CefWrapper`, `Program`) rather than introducing new globals.
+* When adjusting frame rate or resolution, ensure both CefSharp (`WindowlessFrameRate`, browser size) and NDI (`frame_rate_N/D`, `xres`, `yres`) stay in sync.
+* Document new HTTP endpoints in both README and `Tractus.HtmlToNdi.http`.
 
 ---
 
-## 12) Provenance / references (for maintainers)
+## 12) Provenance / references
 
-* Architecture & behavior summary (merged into this doc from the supplied analysis of the repo). 
-* Public repo (README with usage/limits):
-  [https://github.com/tractusevents/Tractus.HtmlToNdi](https://github.com/tractusevents/Tractus.HtmlToNdi)
+* Source: repo inspection (2024-10 snapshot) of Program.cs, Chromium/*, Models/*, README.
+* Public releases & documentation: [https://github.com/tractusevents/Tractus.HtmlToNdi](https://github.com/tractusevents/Tractus.HtmlToNdi).
 
 **End of AGENTS.md**


### PR DESCRIPTION
## Summary
- rewrite AGENTS.md to document the present Chromium → NDI workflow, HTTP API endpoints, and CLI defaults
- add dedicated sections outlining the NDI send path, current KVM metadata handling, constraints, and roadmap priorities
- fill appendices with concrete file-level notes for Chromium helpers, models, and outstanding TODOs

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d965bea6288329bb459e5daffb0a45