### PR TITLE
Implement frame pacing with ring buffer

### DIFF
--- a/Chromium/CefWrapper.cs
+++ b/Chromium/CefWrapper.cs
@@ -1,7 +1,9 @@
-
+using System;
 using CefSharp;
 using CefSharp.OffScreen;
 using NewTek;
+using Serilog;
+using Tractus.HtmlToNdi.Video;
 
 namespace Tractus.HtmlToNdi.Chromium;
 
@@ -9,6 +11,9 @@ public class CefWrapper : IDisposable
 {
     private bool disposedValue;
     private ChromiumWebBrowser? browser;
+    private readonly FrameRingBuffer frameBuffer;
+    private readonly FrameRate targetFrameRate;
+    private readonly int chromiumFrameRate;
 
     public int Width { get; private set; }
     public int Height { get; private set; }
@@ -18,11 +23,14 @@ public class CefWrapper : IDisposable
     private Thread RenderWatchdog;
     private DateTime lastPaint = DateTime.MinValue;
 
-    public CefWrapper(int width, int height, string initialUrl)
+    public CefWrapper(int width, int height, string initialUrl, FrameRingBuffer frameBuffer, FrameRate targetFrameRate)
     {
         this.Width = width;
         this.Height = height;
         this.Url = initialUrl;
+        this.frameBuffer = frameBuffer ?? throw new ArgumentNullException(nameof(frameBuffer));
+        this.targetFrameRate = targetFrameRate;
+        this.chromiumFrameRate = Math.Max(60, (int)Math.Ceiling(this.targetFrameRate.FramesPerSecond * 2));
 
         this.browser = new ChromiumWebBrowser(initialUrl)
         {
@@ -56,7 +64,7 @@ public class CefWrapper : IDisposable
 
         await this.browser.WaitForInitialLoadAsync();
 
-        this.browser.GetBrowserHost().WindowlessFrameRate = 60;
+        this.browser.GetBrowserHost().WindowlessFrameRate = this.chromiumFrameRate;
         this.browser.ToggleAudioMute();
 
         this.browser.Paint += this.OnBrowserPaint;
@@ -65,35 +73,27 @@ public class CefWrapper : IDisposable
 
     private void OnBrowserPaint(object? sender, OnPaintEventArgs e)
     {
-        if (Program.NdiSenderPtr == nint.Zero)
-        {
-            return;
-        }
-
-        var browser = sender as ChromiumWebBrowser;
-
-        if (browser is null)
+        if (this.frameBuffer is null)
         {
             return;
         }
 
         this.lastPaint = DateTime.Now;
-
-        var videoFrame = new NDIlib.video_frame_v2_t()
+        if (e.Width <= 0 || e.Height <= 0)
         {
-            FourCC = NDIlib.FourCC_type_e.FourCC_type_BGRA,
-            frame_rate_N = 60,
-            frame_rate_D = 1,
-            frame_format_type = NDIlib.frame_format_type_e.frame_format_type_progressive,
-            line_stride_in_bytes = e.Width * 4,
-            picture_aspect_ratio = (float)e.Width / e.Height,
-            p_data = e.BufferHandle,
-            timecode = NDIlib.send_timecode_synthesize,
-            xres = e.Width,
-            yres = e.Height,
-        };
+            return;
+        }
 
-        NDIlib.send_send_video_v2(Program.NdiSenderPtr, ref videoFrame);
+        var stride = e.Width * 4;
+        var expectedLength = stride * e.Height;
+        if (e.Buffer is null || e.Buffer.Length < expectedLength)
+        {
+            Log.Warning("Received paint buffer smaller than expected (length={Length}, expected={Expected}).", e.Buffer?.Length ?? 0, expectedLength);
+            return;
+        }
+
+        var pixels = new ReadOnlySpan<byte>(e.Buffer, 0, expectedLength);
+        this.frameBuffer.WriteFrame(pixels, e.Width, e.Height, stride, DateTime.UtcNow);
     }
 
     protected virtual void Dispose(bool disposing)

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Tractus.HtmlToNdi.Tests")]

--- a/README.md
+++ b/README.md
@@ -15,14 +15,22 @@ If the web page you are loading has a transparent background, NDI will honor tha
 Parameter|Description
 ----|---
 `--ndiname="NDI Source Name"`|The source name this browser instance will send. Defaults to "`HTML5`".
-`--width=1920`|The width of the browser source. Defaults to `1920`.
-`--width=1080`|The height of the browser source. Defaults to `1080`.
+`--w=1920`|The width of the browser source. Defaults to `1920`.
+`--h=1080`|The height of the browser source. Defaults to `1080`.
 `--port=9999`|The port the HTTP server will listen on. Defaults to `9999`.
 `--url="https://www.tractus.ca"`|The startup webpage. Defaults to `https://testpattern.tractusevents.com/`.
+`--fps=30000/1001`|Target NDI output frame rate. Accepts ratios (e.g. `30000/1001`) or decimals (e.g. `29.97`). Defaults to ~29.97 fps.
+`--buffer-depth=5`|Number of frames retained in the pacing buffer. Higher values smooth bursts at the cost of latency. Defaults to `5`.
+`--disable-gpu-vsync`|Passes `--disable-gpu-vsync` to Chromium. Useful when the host GPU forces vsync.
+`--disable-frame-rate-limit`|Passes `--disable-frame-rate-limit` to Chromium. Allows Chromium to render as quickly as possible.
 
 #### Example Launch
 
-`.\Tractus.HtmlToNdi.exe --ndiname="HTML 5 Test" --w=1080 --h=1080 --url="https://testpattern.tractusevents.com"`
+`.\Tractus.HtmlToNdi.exe --ndiname="HTML 5 Test" --w=1080 --h=1080 --fps=30000/1001 --buffer-depth=5 --url="https://testpattern.tractusevents.com"`
+
+## Frame pacing and telemetry
+
+Chromium paint callbacks enqueue frames into a fixed-size ring buffer. A dedicated pacing thread wakes at the configured frame interval and submits the latest frame to NDI, repeating the last frame if Chromium has not produced a new one. Serilog logs aggregate stats (average interval, min/max jitter, repeated and dropped counts) once per second by default—watch the console or log file to validate pacing performance.
 
 ## API Routes
 
@@ -35,7 +43,7 @@ Route|Method|Description|Example
 - Frames are sent to NDI in RGBA format. Some machines may experience a slight performance penalty.
 - H.264 and any other non-free codecs are not available for video playback since this uses Chromium. Sites like YouTube likely won't work.
 - Audio data received from the browser is passed to NDI directly.
-- NDI frame rate is set to 60 frames per second. The internal max render frame rate is set to be capped at 60 frames per second.
+- Video frames are paced to the configured frame rate (default 30000/1001). Increase `--buffer-depth` if receivers report repeated frames during bursty rendering.
 
 ## More Tools
 

--- a/Tests/Tractus.HtmlToNdi.Tests/FramePacerTests.cs
+++ b/Tests/Tractus.HtmlToNdi.Tests/FramePacerTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Tractus.HtmlToNdi.Video;
+using Xunit;
+
+namespace Tractus.HtmlToNdi.Tests;
+
+public class FramePacerTests
+{
+    [Fact]
+    public void RunTick_RepeatsLastFrameWhenNoNewData()
+    {
+        var buffer = new FrameRingBuffer(4);
+        var outputs = new List<FrameOutput>();
+        var options = new FramePacerOptions
+        {
+            StartImmediately = false,
+            MetricsLogInterval = TimeSpan.FromHours(1)
+        };
+
+        using var pacer = new FramePacer(buffer, FrameRate.Ntsc2997, outputs.Add, options);
+        var now = DateTime.UtcNow;
+
+        pacer.RunTick(now);
+        Assert.Empty(outputs);
+
+        var pixels = CreatePixels(1, 2, 0x10);
+        buffer.WriteFrame(pixels, 1, 2, 4, now);
+
+        var firstTick = now + pacer.TargetInterval;
+        pacer.RunTick(firstTick);
+
+        Assert.Single(outputs);
+        Assert.False(outputs[0].IsRepeat);
+        Assert.Equal(1, outputs[0].Metadata.Width);
+        Assert.Equal(2, outputs[0].Metadata.Height);
+        Assert.Equal(pixels, outputs[0].PixelData.ToArray());
+
+        var secondTick = firstTick + pacer.TargetInterval;
+        pacer.RunTick(secondTick);
+
+        Assert.Equal(2, outputs.Count);
+        Assert.True(outputs[1].IsRepeat);
+        Assert.Equal(outputs[0].PixelData.ToArray(), outputs[1].PixelData.ToArray());
+
+        var burstFrameA = CreatePixels(1, 2, 0x20);
+        var burstFrameB = CreatePixels(1, 2, 0x30);
+        buffer.WriteFrame(burstFrameA, 1, 2, 4, secondTick + TimeSpan.FromMilliseconds(5));
+        buffer.WriteFrame(burstFrameB, 1, 2, 4, secondTick + TimeSpan.FromMilliseconds(10));
+
+        var thirdTick = secondTick + pacer.TargetInterval;
+        pacer.RunTick(thirdTick);
+
+        Assert.Equal(3, outputs.Count);
+        var latest = outputs.Last();
+        Assert.False(latest.IsRepeat);
+        Assert.Equal(1, latest.DroppedFrames);
+        Assert.Equal(burstFrameB, latest.PixelData.ToArray());
+    }
+
+    private static byte[] CreatePixels(int width, int height, byte seed)
+    {
+        var length = width * height * 4;
+        var pixels = new byte[length];
+        for (var i = 0; i < length; i++)
+        {
+            pixels[i] = (byte)(seed + i);
+        }
+
+        return pixels;
+    }
+}

--- a/Tests/Tractus.HtmlToNdi.Tests/FrameRingBufferTests.cs
+++ b/Tests/Tractus.HtmlToNdi.Tests/FrameRingBufferTests.cs
@@ -1,0 +1,57 @@
+using System;
+using Tractus.HtmlToNdi.Video;
+using Xunit;
+
+namespace Tractus.HtmlToNdi.Tests;
+
+public class FrameRingBufferTests
+{
+    [Fact]
+    public void TryCopyLatest_ReturnsLatestFrameAndDropCount()
+    {
+        var buffer = new FrameRingBuffer(3);
+        var firstPixels = CreatePixels(1, 3, 10);
+        var secondPixels = CreatePixels(1, 3, 20);
+        var thirdPixels = CreatePixels(1, 3, 30);
+        var destination = new byte[firstPixels.Length];
+
+        buffer.WriteFrame(firstPixels, 1, 3, 4, DateTime.UtcNow);
+        Assert.True(buffer.TryCopyLatest(destination, out var metadata, out var dropped));
+        Assert.Equal(0, dropped);
+        Assert.Equal(1, metadata.Width);
+        Assert.Equal(3, metadata.Height);
+        Assert.Equal(firstPixels, destination);
+
+        buffer.WriteFrame(secondPixels, 1, 3, 4, DateTime.UtcNow);
+        buffer.WriteFrame(thirdPixels, 1, 3, 4, DateTime.UtcNow);
+
+        Assert.True(buffer.TryCopyLatest(destination, out metadata, out dropped));
+        Assert.Equal(1, dropped);
+        Assert.Equal(thirdPixels, destination);
+
+        Assert.False(buffer.TryCopyLatest(destination, out metadata, out dropped));
+    }
+
+    [Fact]
+    public void TryCopyLatest_ReturnsFalseWhenEmpty()
+    {
+        var buffer = new FrameRingBuffer(2);
+        var destination = new byte[8];
+
+        Assert.False(buffer.TryCopyLatest(destination, out var metadata, out var dropped));
+        Assert.Equal(default, metadata);
+        Assert.Equal(0, dropped);
+    }
+
+    private static byte[] CreatePixels(int width, int height, byte seed)
+    {
+        var length = width * height * 4;
+        var pixels = new byte[length];
+        for (var i = 0; i < length; i++)
+        {
+            pixels[i] = (byte)(seed + i);
+        }
+
+        return pixels;
+    }
+}

--- a/Tests/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
+++ b/Tests/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Tractus.HtmlToNdi.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tractus.HtmlToNdi.sln
+++ b/Tractus.HtmlToNdi.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.11.35303.130
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tractus.HtmlToNdi", "Tractus.HtmlToNdi.csproj", "{6B6C038D-3984-455A-95CA-A9079B3FC4E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tractus.HtmlToNdi.Tests", "Tests\\Tractus.HtmlToNdi.Tests\\Tractus.HtmlToNdi.Tests.csproj", "{33DFF028-34F6-4DF8-928F-5343A680481C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,10 +20,18 @@ Global
 		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|x64.ActiveCfg = Debug|x64
 		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|x64.Build.0 = Debug|x64
 		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.ActiveCfg = Release|x64
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.Build.0 = Release|x64
-	EndGlobalSection
+                {6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.Build.0 = Release|Any CPU
+                {6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.ActiveCfg = Release|x64
+                {6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.Build.0 = Release|x64
+                {33DFF028-34F6-4DF8-928F-5343A680481C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {33DFF028-34F6-4DF8-928F-5343A680481C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {33DFF028-34F6-4DF8-928F-5343A680481C}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {33DFF028-34F6-4DF8-928F-5343A680481C}.Debug|x64.Build.0 = Debug|Any CPU
+                {33DFF028-34F6-4DF8-928F-5343A680481C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {33DFF028-34F6-4DF8-928F-5343A680481C}.Release|Any CPU.Build.0 = Release|Any CPU
+                {33DFF028-34F6-4DF8-928F-5343A680481C}.Release|x64.ActiveCfg = Release|Any CPU
+                {33DFF028-34F6-4DF8-928F-5343A680481C}.Release|x64.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Video/FrameMetadata.cs
+++ b/Video/FrameMetadata.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public readonly struct FrameMetadata
+{
+    public FrameMetadata(int width, int height, int stride, int bufferLength, DateTime capturedAtUtc)
+    {
+        this.Width = width;
+        this.Height = height;
+        this.Stride = stride;
+        this.BufferLength = bufferLength;
+        this.CapturedAtUtc = capturedAtUtc;
+    }
+
+    public int Width { get; }
+    public int Height { get; }
+    public int Stride { get; }
+    public int BufferLength { get; }
+    public DateTime CapturedAtUtc { get; }
+}

--- a/Video/FrameOutput.cs
+++ b/Video/FrameOutput.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public readonly struct FrameOutput
+{
+    public FrameOutput(FrameMetadata metadata, ReadOnlyMemory<byte> pixelData, bool isRepeat, int droppedFrames, TimeSpan actualInterval)
+    {
+        this.Metadata = metadata;
+        this.PixelData = pixelData;
+        this.IsRepeat = isRepeat;
+        this.DroppedFrames = droppedFrames;
+        this.ActualInterval = actualInterval;
+    }
+
+    public FrameMetadata Metadata { get; }
+    public ReadOnlyMemory<byte> PixelData { get; }
+    public bool IsRepeat { get; }
+    public int DroppedFrames { get; }
+    public TimeSpan ActualInterval { get; }
+}

--- a/Video/FramePacer.cs
+++ b/Video/FramePacer.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using Serilog;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public sealed class FramePacer : IDisposable
+{
+    private readonly FrameRingBuffer buffer;
+    private readonly FrameRate targetFrameRate;
+    private readonly Action<FrameOutput> frameConsumer;
+    private readonly FramePacerOptions options;
+    private readonly object stateLock = new();
+
+    private Thread? workerThread;
+    private bool running;
+    private bool disposed;
+    private byte[] currentFrame = Array.Empty<byte>();
+    private FrameMetadata currentMetadata;
+    private bool hasCurrentFrame;
+    private DateTime lastTickUtc = DateTime.MinValue;
+    private DateTime lastLogUtc = DateTime.MinValue;
+    private readonly Stopwatch stopwatch = new();
+
+    private long sentFrames;
+    private long repeatedFrames;
+    private long droppedFrames;
+    private double minIntervalMs = double.MaxValue;
+    private double maxIntervalMs = 0;
+    private double accumulatedIntervalMs;
+
+    public FramePacer(FrameRingBuffer buffer, FrameRate targetFrameRate, Action<FrameOutput> frameConsumer, FramePacerOptions? options = null)
+    {
+        this.buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+        this.targetFrameRate = targetFrameRate;
+        this.frameConsumer = frameConsumer ?? throw new ArgumentNullException(nameof(frameConsumer));
+        this.options = options ?? new FramePacerOptions();
+
+        if (this.options.StartImmediately)
+        {
+            this.Start();
+        }
+    }
+
+    public TimeSpan TargetInterval => this.targetFrameRate.FrameInterval;
+
+    public void Start()
+    {
+        lock (this.stateLock)
+        {
+            if (this.running)
+            {
+                return;
+            }
+
+            this.running = true;
+            this.workerThread = new Thread(this.Run)
+            {
+                Name = "FramePacer",
+                IsBackground = true,
+                Priority = ThreadPriority.AboveNormal,
+            };
+
+            this.workerThread.Start();
+        }
+    }
+
+    public void Stop()
+    {
+        lock (this.stateLock)
+        {
+            this.running = false;
+        }
+
+        if (this.workerThread is not null && Thread.CurrentThread != this.workerThread)
+        {
+            this.workerThread.Join();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (this.disposed)
+        {
+            return;
+        }
+
+        this.Stop();
+        this.disposed = true;
+    }
+
+    internal void RunTick(DateTime utcNow)
+    {
+        var actualInterval = this.lastTickUtc == DateTime.MinValue
+            ? this.TargetInterval
+            : utcNow - this.lastTickUtc;
+        this.lastTickUtc = utcNow;
+
+        var hasNewFrame = this.TryReadLatestFrame(out var metadata, out var dropped);
+
+        if (hasNewFrame)
+        {
+            this.currentMetadata = metadata;
+            this.hasCurrentFrame = true;
+            this.droppedFrames += dropped;
+        }
+        else if (!this.hasCurrentFrame)
+        {
+            return;
+        }
+        else
+        {
+            this.repeatedFrames++;
+        }
+
+        var output = new FrameOutput(this.currentMetadata, new ReadOnlyMemory<byte>(this.currentFrame, 0, this.currentMetadata.BufferLength), !hasNewFrame, hasNewFrame ? dropped : 0, actualInterval);
+        this.frameConsumer(output);
+        this.sentFrames++;
+
+        this.TrackInterval(actualInterval);
+        this.LogMetricsIfNeeded(utcNow);
+    }
+
+    private void Run()
+    {
+        this.stopwatch.Restart();
+        var nextDeadline = this.stopwatch.Elapsed;
+
+        while (this.running)
+        {
+            nextDeadline += this.TargetInterval;
+            this.SleepUntil(nextDeadline);
+            this.RunTick(DateTime.UtcNow);
+        }
+    }
+
+    private bool TryReadLatestFrame(out FrameMetadata metadata, out int dropped)
+    {
+        metadata = default;
+        dropped = 0;
+
+        while (true)
+        {
+            try
+            {
+                var hasNew = this.buffer.TryCopyLatest(this.currentFrame.AsSpan(), out metadata, out dropped);
+                if (!hasNew)
+                {
+                    return false;
+                }
+
+                if (metadata.BufferLength > this.currentFrame.Length)
+                {
+                    this.currentFrame = new byte[metadata.BufferLength];
+                    continue;
+                }
+
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                var snapshot = this.buffer.GetLatestSnapshot();
+                var required = snapshot.HasValue ? snapshot.Metadata.BufferLength : metadata.BufferLength;
+                if (required <= 0)
+                {
+                    return false;
+                }
+
+                this.currentFrame = new byte[required];
+            }
+        }
+    }
+
+    private void SleepUntil(TimeSpan target)
+    {
+        while (true)
+        {
+            var remaining = target - this.stopwatch.Elapsed;
+            if (remaining <= TimeSpan.Zero)
+            {
+                return;
+            }
+
+            if (remaining > TimeSpan.FromMilliseconds(2))
+            {
+                Thread.Sleep(remaining - TimeSpan.FromMilliseconds(1));
+            }
+            else
+            {
+                Thread.SpinWait(50);
+            }
+        }
+    }
+
+    private void TrackInterval(TimeSpan interval)
+    {
+        var intervalMs = interval.TotalMilliseconds;
+        this.accumulatedIntervalMs += intervalMs;
+        this.minIntervalMs = Math.Min(this.minIntervalMs, intervalMs);
+        this.maxIntervalMs = Math.Max(this.maxIntervalMs, intervalMs);
+    }
+
+    private void LogMetricsIfNeeded(DateTime utcNow)
+    {
+        if (this.lastLogUtc != DateTime.MinValue && utcNow - this.lastLogUtc < this.options.MetricsLogInterval)
+        {
+            return;
+        }
+
+        var sent = this.sentFrames;
+        if (sent == 0)
+        {
+            return;
+        }
+
+        var avg = this.accumulatedIntervalMs / sent;
+        Log.Information("Frame pacer stats: sent={Sent} repeat={Repeated} dropped={Dropped} interval_avg={Avg:F3}ms interval_min={Min:F3}ms interval_max={Max:F3}ms target={Target:F3}ms buffer_depth={BufferDepth}",
+            sent,
+            this.repeatedFrames,
+            this.droppedFrames,
+            avg,
+            this.minIntervalMs,
+            this.maxIntervalMs,
+            this.TargetInterval.TotalMilliseconds,
+            this.buffer.Capacity);
+
+        this.lastLogUtc = utcNow;
+        this.accumulatedIntervalMs = 0;
+        this.minIntervalMs = double.MaxValue;
+        this.maxIntervalMs = 0;
+        this.sentFrames = 0;
+        this.repeatedFrames = 0;
+        this.droppedFrames = 0;
+    }
+}

--- a/Video/FramePacerOptions.cs
+++ b/Video/FramePacerOptions.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public sealed class FramePacerOptions
+{
+    public bool StartImmediately { get; set; } = true;
+    public TimeSpan MetricsLogInterval { get; set; } = TimeSpan.FromSeconds(1);
+}

--- a/Video/FrameRate.cs
+++ b/Video/FrameRate.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Globalization;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public readonly struct FrameRate
+{
+    public int Numerator { get; }
+    public int Denominator { get; }
+
+    public double FramesPerSecond => (double)this.Numerator / this.Denominator;
+    public TimeSpan FrameInterval => TimeSpan.FromSeconds((double)this.Denominator / this.Numerator);
+
+    private FrameRate(int numerator, int denominator)
+    {
+        if (numerator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(numerator));
+        }
+
+        if (denominator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(denominator));
+        }
+
+        this.Numerator = numerator;
+        this.Denominator = denominator;
+    }
+
+    public static FrameRate Create(int numerator, int denominator)
+    {
+        var gcd = GreatestCommonDivisor(Math.Abs(numerator), Math.Abs(denominator));
+        return new FrameRate(numerator / gcd, denominator / gcd);
+    }
+
+    public static FrameRate FromDouble(double framesPerSecond, int precision = 1000)
+    {
+        if (framesPerSecond <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(framesPerSecond));
+        }
+
+        var denominator = Math.Max(1, precision);
+        var numerator = (int)Math.Round(framesPerSecond * denominator, MidpointRounding.AwayFromZero);
+
+        if (numerator == 0)
+        {
+            numerator = 1;
+        }
+
+        return Create(numerator, denominator);
+    }
+
+    public static bool TryParse(string value, out FrameRate frameRate)
+    {
+        frameRate = default;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        value = value.Trim();
+        if (value.Contains('/'))
+        {
+            var parts = value.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length != 2)
+            {
+                return false;
+            }
+
+            if (int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var numerator) &&
+                int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var denominator))
+            {
+                frameRate = Create(numerator, denominator);
+                return true;
+            }
+
+            return false;
+        }
+
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var fps))
+        {
+            frameRate = FromDouble(fps);
+            return true;
+        }
+
+        return false;
+    }
+
+    public override string ToString()
+    {
+        return $"{this.Numerator}/{this.Denominator} ({this.FramesPerSecond:F3} fps)";
+    }
+
+    public static FrameRate Ntsc2997 { get; } = Create(30000, 1001);
+
+    private static int GreatestCommonDivisor(int a, int b)
+    {
+        while (b != 0)
+        {
+            var temp = b;
+            b = a % b;
+            a = temp;
+        }
+
+        return a == 0 ? 1 : a;
+    }
+}

--- a/Video/FrameRingBuffer.cs
+++ b/Video/FrameRingBuffer.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Threading;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public sealed class FrameRingBuffer
+{
+    private readonly FrameSlot[] slots;
+    private readonly int capacity;
+    private long writeSequence = -1;
+    private long publishedSequence = -1;
+    private long lastReadSequence = -1;
+
+    public FrameRingBuffer(int capacity)
+    {
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity));
+        }
+
+        this.capacity = capacity;
+        this.slots = new FrameSlot[capacity];
+        for (var i = 0; i < capacity; i++)
+        {
+            this.slots[i] = new FrameSlot();
+        }
+    }
+
+    public int Capacity => this.capacity;
+
+    public void WriteFrame(ReadOnlySpan<byte> pixels, int width, int height, int stride, DateTime capturedAtUtc)
+    {
+        var sequence = Interlocked.Increment(ref this.writeSequence);
+        var slot = this.slots[(int)(sequence % this.capacity)];
+        slot.Write(pixels, width, height, stride, capturedAtUtc);
+        Volatile.Write(ref this.publishedSequence, sequence);
+    }
+
+    public bool TryCopyLatest(Span<byte> destination, out FrameMetadata metadata, out int droppedFrames)
+    {
+        metadata = default;
+        droppedFrames = 0;
+
+        var published = Volatile.Read(ref this.publishedSequence);
+        if (published < 0)
+        {
+            return false;
+        }
+
+        var lastRead = Volatile.Read(ref this.lastReadSequence);
+        if (published == lastRead)
+        {
+            return false;
+        }
+
+        var slot = this.slots[(int)(published % this.capacity)];
+        slot.CopyTo(destination);
+        metadata = slot.Metadata;
+        droppedFrames = (int)Math.Max(0, published - lastRead - 1);
+        Volatile.Write(ref this.lastReadSequence, published);
+        return true;
+    }
+
+    public FrameBufferSnapshot GetLatestSnapshot()
+    {
+        var published = Volatile.Read(ref this.publishedSequence);
+        if (published < 0)
+        {
+            return FrameBufferSnapshot.Empty;
+        }
+
+        var slot = this.slots[(int)(published % this.capacity)];
+        return new FrameBufferSnapshot(slot.Metadata, slot.AsMemory());
+    }
+
+    private sealed class FrameSlot
+    {
+        private byte[] buffer = Array.Empty<byte>();
+        private FrameMetadata metadata;
+
+        public FrameMetadata Metadata => this.metadata;
+
+        public void Write(ReadOnlySpan<byte> pixels, int width, int height, int stride, DateTime capturedAtUtc)
+        {
+            var required = pixels.Length;
+            if (this.buffer.Length < required)
+            {
+                this.buffer = new byte[required];
+            }
+
+            pixels.CopyTo(this.buffer);
+            this.metadata = new FrameMetadata(width, height, stride, required, capturedAtUtc);
+        }
+
+        public void CopyTo(Span<byte> destination)
+        {
+            if (destination.Length < this.metadata.BufferLength)
+            {
+                throw new ArgumentException("Destination buffer too small", nameof(destination));
+            }
+
+            this.buffer.AsSpan(0, this.metadata.BufferLength).CopyTo(destination);
+        }
+
+        public ReadOnlyMemory<byte> AsMemory() => new ReadOnlyMemory<byte>(this.buffer, 0, this.metadata.BufferLength);
+    }
+}
+
+public readonly struct FrameBufferSnapshot
+{
+    public static readonly FrameBufferSnapshot Empty = new FrameBufferSnapshot(default, ReadOnlyMemory<byte>.Empty);
+
+    public FrameBufferSnapshot(FrameMetadata metadata, ReadOnlyMemory<byte> buffer)
+    {
+        this.Metadata = metadata;
+        this.Buffer = buffer;
+    }
+
+    public FrameMetadata Metadata { get; }
+    public ReadOnlyMemory<byte> Buffer { get; }
+
+    public bool HasValue => this.Buffer.Length > 0;
+}


### PR DESCRIPTION
## Summary
- introduce a frame ring buffer, frame pacer, and frame rate helpers to decouple Chromium capture from NDI transmission
- update the Cef wrapper and program startup to feed the buffer, expose frame pacing options, and log pacing metrics
- add xUnit tests for the ring buffer and pacer and document the new configuration and behaviour

## Testing
- dotnet --version *(fails: `command not found` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da25763f448329ae00c87d15e52fbc