### PR TITLE
Implement frame pacing buffer and tests

### DIFF
--- a/Chromium/CefWrapper.cs
+++ b/Chromium/CefWrapper.cs
@@ -2,11 +2,14 @@
 using CefSharp;
 using CefSharp.OffScreen;
 using NewTek;
+using Serilog;
+using Tractus.HtmlToNdi.FramePacing;
 
 namespace Tractus.HtmlToNdi.Chromium;
 
 public class CefWrapper : IDisposable
 {
+    private readonly FrameRingBuffer<BrowserFrame> frameBuffer;
     private bool disposedValue;
     private ChromiumWebBrowser? browser;
 
@@ -18,11 +21,12 @@ public class CefWrapper : IDisposable
     private Thread RenderWatchdog;
     private DateTime lastPaint = DateTime.MinValue;
 
-    public CefWrapper(int width, int height, string initialUrl)
+    public CefWrapper(int width, int height, string initialUrl, FrameRingBuffer<BrowserFrame> frameBuffer)
     {
         this.Width = width;
         this.Height = height;
         this.Url = initialUrl;
+        this.frameBuffer = frameBuffer;
 
         this.browser = new ChromiumWebBrowser(initialUrl)
         {
@@ -65,11 +69,6 @@ public class CefWrapper : IDisposable
 
     private void OnBrowserPaint(object? sender, OnPaintEventArgs e)
     {
-        if (Program.NdiSenderPtr == nint.Zero)
-        {
-            return;
-        }
-
         var browser = sender as ChromiumWebBrowser;
 
         if (browser is null)
@@ -79,21 +78,21 @@ public class CefWrapper : IDisposable
 
         this.lastPaint = DateTime.Now;
 
-        var videoFrame = new NDIlib.video_frame_v2_t()
+        if (this.frameBuffer is null)
         {
-            FourCC = NDIlib.FourCC_type_e.FourCC_type_BGRA,
-            frame_rate_N = 60,
-            frame_rate_D = 1,
-            frame_format_type = NDIlib.frame_format_type_e.frame_format_type_progressive,
-            line_stride_in_bytes = e.Width * 4,
-            picture_aspect_ratio = (float)e.Width / e.Height,
-            p_data = e.BufferHandle,
-            timecode = NDIlib.send_timecode_synthesize,
-            xres = e.Width,
-            yres = e.Height,
-        };
+            Log.Warning("Frame buffer not configured; dropping frame");
+            return;
+        }
 
-        NDIlib.send_send_video_v2(Program.NdiSenderPtr, ref videoFrame);
+        var frame = new BrowserFrame(
+            e.BufferHandle,
+            e.Width,
+            e.Height,
+            e.Width * 4,
+            (float)e.Width / e.Height,
+            DateTime.UtcNow);
+
+        this.frameBuffer.Push(frame);
     }
 
     protected virtual void Dispose(bool disposing)

--- a/FramePacing/BrowserFrame.cs
+++ b/FramePacing/BrowserFrame.cs
@@ -1,0 +1,18 @@
+using System.Runtime.InteropServices;
+
+namespace Tractus.HtmlToNdi.FramePacing;
+
+/// <summary>
+/// Represents a frame produced by the Chromium renderer.
+/// </summary>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct BrowserFrame(
+    nint BufferHandle,
+    int Width,
+    int Height,
+    int Stride,
+    float AspectRatio,
+    DateTime CapturedAt)
+{
+    public bool HasBuffer => this.BufferHandle != nint.Zero;
+}

--- a/FramePacing/BrowserFrame.cs
+++ b/FramePacing/BrowserFrame.cs
@@ -1,18 +1,15 @@
-using System.Runtime.InteropServices;
-
 namespace Tractus.HtmlToNdi.FramePacing;
 
 /// <summary>
 /// Represents a frame produced by the Chromium renderer.
 /// </summary>
-[StructLayout(LayoutKind.Auto)]
 public readonly record struct BrowserFrame(
-    nint BufferHandle,
+    byte[] PixelBuffer,
     int Width,
     int Height,
     int Stride,
     float AspectRatio,
     DateTime CapturedAt)
 {
-    public bool HasBuffer => this.BufferHandle != nint.Zero;
+    public bool HasBuffer => this.PixelBuffer is { Length: > 0 };
 }

--- a/FramePacing/FrameDeliveryContext.cs
+++ b/FramePacing/FrameDeliveryContext.cs
@@ -1,0 +1,10 @@
+namespace Tractus.HtmlToNdi.FramePacing;
+
+/// <summary>
+/// Provides context for a paced frame send.
+/// </summary>
+public readonly record struct FrameDeliveryContext(
+    bool IsRepeat,
+    int DroppedFrames,
+    TimeSpan Latency,
+    int Backlog);

--- a/FramePacing/FramePacer.cs
+++ b/FramePacing/FramePacer.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics;
+using System.Threading;
+
+namespace Tractus.HtmlToNdi.FramePacing;
+
+public sealed class FramePacer : IDisposable
+{
+    private readonly FramePacerEngine engine;
+    private readonly CancellationTokenSource cancellationTokenSource = new();
+    private Thread? workerThread;
+    private bool disposed;
+
+    public FramePacer(FramePacerEngine engine)
+    {
+        this.engine = engine;
+    }
+
+    public FramePacer(FrameRingBuffer<BrowserFrame> buffer, FrameRate frameRate, Action<BrowserFrame, FrameDeliveryContext> sendFrame, Serilog.ILogger logger)
+        : this(new FramePacerEngine(buffer, frameRate, sendFrame, logger))
+    {
+    }
+
+    public FrameRate FrameRate => this.engine.FrameRate;
+
+    public void Start()
+    {
+        if (this.workerThread != null)
+        {
+            return;
+        }
+
+        this.workerThread = new Thread(this.RunLoop)
+        {
+            IsBackground = true,
+            Name = "FramePacer",
+            Priority = ThreadPriority.AboveNormal,
+        };
+        this.workerThread.Start();
+    }
+
+    public FramePacerMetrics GetMetricsSnapshot() => this.engine.GetMetricsSnapshot();
+
+    private void RunLoop()
+    {
+        var token = this.cancellationTokenSource.Token;
+        var interval = this.engine.Interval;
+        var stopwatch = Stopwatch.StartNew();
+        var nextTick = stopwatch.Elapsed;
+
+        while (!token.IsCancellationRequested)
+        {
+            var remaining = nextTick - stopwatch.Elapsed;
+            if (remaining > TimeSpan.Zero)
+            {
+                if (remaining > TimeSpan.FromMilliseconds(2))
+                {
+                    Thread.Sleep(remaining - TimeSpan.FromMilliseconds(1));
+                }
+                else
+                {
+                    SpinWait.SpinUntil(() => stopwatch.Elapsed >= nextTick || token.IsCancellationRequested, remaining);
+                }
+            }
+            else
+            {
+                nextTick = stopwatch.Elapsed;
+            }
+
+            if (token.IsCancellationRequested)
+            {
+                break;
+            }
+
+            this.engine.ProcessTick(DateTime.UtcNow);
+            nextTick += interval;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (this.disposed)
+        {
+            return;
+        }
+
+        this.cancellationTokenSource.Cancel();
+        this.workerThread?.Join();
+        this.workerThread = null;
+        this.cancellationTokenSource.Dispose();
+        this.disposed = true;
+    }
+}

--- a/FramePacing/FramePacerEngine.cs
+++ b/FramePacing/FramePacerEngine.cs
@@ -1,0 +1,284 @@
+using Serilog;
+
+namespace Tractus.HtmlToNdi.FramePacing;
+
+internal sealed class FramePacerEngine
+{
+    private static readonly TimeSpan MetricsLogInterval = TimeSpan.FromSeconds(1);
+
+    private readonly FrameRingBuffer<BrowserFrame> buffer;
+    private readonly Action<BrowserFrame, FrameDeliveryContext> sendFrame;
+    private readonly ILogger logger;
+
+    private readonly TimeSpan interval;
+
+    private BrowserFrame? lastFrame;
+    private long lastSequence = -1;
+    private DateTime? lastTickTime;
+    private DateTime lastMetricsLog = DateTime.MinValue;
+
+    private long totalFramesSent;
+    private long totalRepeats;
+    private long totalDrops;
+
+    private TimeSpan totalIntervalSum = TimeSpan.Zero;
+    private long totalIntervalCount;
+    private TimeSpan totalIntervalMin = TimeSpan.MaxValue;
+    private TimeSpan totalIntervalMax = TimeSpan.Zero;
+
+    private TimeSpan totalLatencySum = TimeSpan.Zero;
+    private long totalLatencyCount;
+    private TimeSpan totalLatencyMin = TimeSpan.MaxValue;
+    private TimeSpan totalLatencyMax = TimeSpan.Zero;
+
+    private TimeSpan logIntervalSum = TimeSpan.Zero;
+    private long logIntervalCount;
+    private TimeSpan logIntervalMin = TimeSpan.MaxValue;
+    private TimeSpan logIntervalMax = TimeSpan.Zero;
+
+    private TimeSpan logLatencySum = TimeSpan.Zero;
+    private long logLatencyCount;
+    private TimeSpan logLatencyMin = TimeSpan.MaxValue;
+    private TimeSpan logLatencyMax = TimeSpan.Zero;
+
+    private long logRepeats;
+    private long logDrops;
+
+    public FramePacerEngine(
+        FrameRingBuffer<BrowserFrame> buffer,
+        FrameRate frameRate,
+        Action<BrowserFrame, FrameDeliveryContext> sendFrame,
+        ILogger logger)
+    {
+        this.buffer = buffer;
+        this.FrameRate = frameRate;
+        this.interval = TimeSpan.FromSeconds(frameRate.Denominator / (double)frameRate.Numerator);
+        this.sendFrame = sendFrame;
+        this.logger = logger;
+    }
+
+    public FrameRate FrameRate { get; }
+
+    public TimeSpan Interval => this.interval;
+
+    public void ProcessTick(DateTime tickTime)
+    {
+        var backlog = this.buffer.GetBacklog(this.lastSequence);
+        this.UpdateIntervalStats(tickTime);
+
+        var sentFrame = false;
+        var repeated = false;
+
+        if (this.buffer.TryGetLatest(ref this.lastSequence, out var frame, out var dropped))
+        {
+            this.lastFrame = frame;
+            this.totalDrops += dropped;
+            this.logDrops += dropped;
+
+            var latency = tickTime - frame.CapturedAt;
+            this.RecordLatency(latency);
+
+            this.InvokeSend(frame, new FrameDeliveryContext(false, dropped, latency, backlog));
+            sentFrame = true;
+        }
+        else if (this.lastFrame.HasValue)
+        {
+            var frameToRepeat = this.lastFrame.Value;
+            var latency = tickTime - frameToRepeat.CapturedAt;
+            this.InvokeSend(frameToRepeat, new FrameDeliveryContext(true, 0, latency, backlog));
+            this.totalRepeats++;
+            this.logRepeats++;
+            sentFrame = true;
+            repeated = true;
+        }
+
+        if (sentFrame)
+        {
+            this.totalFramesSent++;
+        }
+
+        this.MaybeLog(tickTime, backlog, repeated);
+    }
+
+    public FramePacerMetrics GetMetricsSnapshot()
+    {
+        double? avgInterval = this.totalIntervalCount > 0
+            ? this.totalIntervalSum.TotalMilliseconds / this.totalIntervalCount
+            : null;
+        double? minInterval = this.totalIntervalCount > 0 && this.totalIntervalMin != TimeSpan.MaxValue
+            ? this.totalIntervalMin.TotalMilliseconds
+            : null;
+        double? maxInterval = this.totalIntervalCount > 0 && this.totalIntervalMax != TimeSpan.Zero
+            ? this.totalIntervalMax.TotalMilliseconds
+            : null;
+
+        double? avgLatency = this.totalLatencyCount > 0
+            ? this.totalLatencySum.TotalMilliseconds / this.totalLatencyCount
+            : null;
+        double? minLatency = this.totalLatencyCount > 0 && this.totalLatencyMin != TimeSpan.MaxValue
+            ? this.totalLatencyMin.TotalMilliseconds
+            : null;
+        double? maxLatency = this.totalLatencyCount > 0 && this.totalLatencyMax != TimeSpan.Zero
+            ? this.totalLatencyMax.TotalMilliseconds
+            : null;
+
+        return new FramePacerMetrics(
+            this.totalFramesSent,
+            this.totalRepeats,
+            this.totalDrops,
+            avgInterval,
+            minInterval,
+            maxInterval,
+            avgLatency,
+            minLatency,
+            maxLatency,
+            this.FrameRate.FramesPerSecond,
+            this.buffer.Capacity);
+    }
+
+    private void UpdateIntervalStats(DateTime tickTime)
+    {
+        if (this.lastTickTime.HasValue)
+        {
+            var delta = tickTime - this.lastTickTime.Value;
+            if (delta < TimeSpan.Zero)
+            {
+                delta = TimeSpan.Zero;
+            }
+
+            this.totalIntervalSum += delta;
+            this.totalIntervalCount++;
+            if (delta < this.totalIntervalMin)
+            {
+                this.totalIntervalMin = delta;
+            }
+
+            if (delta > this.totalIntervalMax)
+            {
+                this.totalIntervalMax = delta;
+            }
+
+            this.logIntervalSum += delta;
+            this.logIntervalCount++;
+            if (delta < this.logIntervalMin)
+            {
+                this.logIntervalMin = delta;
+            }
+
+            if (delta > this.logIntervalMax)
+            {
+                this.logIntervalMax = delta;
+            }
+        }
+
+        this.lastTickTime = tickTime;
+    }
+
+    private void RecordLatency(TimeSpan latency)
+    {
+        if (latency < TimeSpan.Zero)
+        {
+            latency = TimeSpan.Zero;
+        }
+
+        this.totalLatencySum += latency;
+        this.totalLatencyCount++;
+        if (latency < this.totalLatencyMin)
+        {
+            this.totalLatencyMin = latency;
+        }
+
+        if (latency > this.totalLatencyMax)
+        {
+            this.totalLatencyMax = latency;
+        }
+
+        this.logLatencySum += latency;
+        this.logLatencyCount++;
+        if (latency < this.logLatencyMin)
+        {
+            this.logLatencyMin = latency;
+        }
+
+        if (latency > this.logLatencyMax)
+        {
+            this.logLatencyMax = latency;
+        }
+    }
+
+    private void MaybeLog(DateTime tickTime, int backlog, bool repeated)
+    {
+        if ((tickTime - this.lastMetricsLog) < MetricsLogInterval)
+        {
+            return;
+        }
+
+        if (this.logIntervalCount == 0 && this.logLatencyCount == 0 && this.logDrops == 0 && this.logRepeats == 0)
+        {
+            this.lastMetricsLog = tickTime;
+            return;
+        }
+
+        var avgInterval = this.logIntervalCount > 0
+            ? this.logIntervalSum.TotalMilliseconds / this.logIntervalCount
+            : (double?)null;
+        var minInterval = this.logIntervalCount > 0 && this.logIntervalMin != TimeSpan.MaxValue
+            ? this.logIntervalMin.TotalMilliseconds
+            : (double?)null;
+        var maxInterval = this.logIntervalCount > 0 && this.logIntervalMax != TimeSpan.Zero
+            ? this.logIntervalMax.TotalMilliseconds
+            : (double?)null;
+
+        var avgLatency = this.logLatencyCount > 0
+            ? this.logLatencySum.TotalMilliseconds / this.logLatencyCount
+            : (double?)null;
+        var minLatency = this.logLatencyCount > 0 && this.logLatencyMin != TimeSpan.MaxValue
+            ? this.logLatencyMin.TotalMilliseconds
+            : (double?)null;
+        var maxLatency = this.logLatencyCount > 0 && this.logLatencyMax != TimeSpan.Zero
+            ? this.logLatencyMax.TotalMilliseconds
+            : (double?)null;
+
+        this.logger.Debug("Frame pacer stats: target {TargetFps:F3} fps, avg interval {AverageInterval} ms (min {MinInterval} / max {MaxInterval}), avg latency {AverageLatency} ms, repeats {Repeats}, drops {Drops}, backlog {Backlog}, lastRepeat {LastRepeat}",
+            this.FrameRate.FramesPerSecond,
+            avgInterval,
+            minInterval,
+            maxInterval,
+            avgLatency,
+            this.logRepeats,
+            this.logDrops,
+            backlog,
+            repeated);
+
+        this.logIntervalSum = TimeSpan.Zero;
+        this.logIntervalCount = 0;
+        this.logIntervalMin = TimeSpan.MaxValue;
+        this.logIntervalMax = TimeSpan.Zero;
+
+        this.logLatencySum = TimeSpan.Zero;
+        this.logLatencyCount = 0;
+        this.logLatencyMin = TimeSpan.MaxValue;
+        this.logLatencyMax = TimeSpan.Zero;
+
+        this.logRepeats = 0;
+        this.logDrops = 0;
+        this.lastMetricsLog = tickTime;
+    }
+
+    private void InvokeSend(BrowserFrame frame, FrameDeliveryContext context)
+    {
+        if (!frame.HasBuffer)
+        {
+            return;
+        }
+
+        try
+        {
+            this.sendFrame(frame, context);
+        }
+        catch (Exception ex)
+        {
+            this.logger.Error(ex, "Frame send failed");
+        }
+    }
+}

--- a/FramePacing/FramePacerMetrics.cs
+++ b/FramePacing/FramePacerMetrics.cs
@@ -1,0 +1,14 @@
+namespace Tractus.HtmlToNdi.FramePacing;
+
+public readonly record struct FramePacerMetrics(
+    long FramesSent,
+    long RepeatedFrames,
+    long DroppedFrames,
+    double? AverageIntervalMilliseconds,
+    double? MinIntervalMilliseconds,
+    double? MaxIntervalMilliseconds,
+    double? AverageLatencyMilliseconds,
+    double? MinLatencyMilliseconds,
+    double? MaxLatencyMilliseconds,
+    double TargetFps,
+    int BufferCapacity);

--- a/FramePacing/FrameRate.cs
+++ b/FramePacing/FrameRate.cs
@@ -1,0 +1,93 @@
+using System.Globalization;
+
+namespace Tractus.HtmlToNdi.FramePacing;
+
+public readonly record struct FrameRate(int Numerator, int Denominator)
+{
+    public static FrameRate Default2997 { get; } = new FrameRate(30000, 1001);
+
+    public double FramesPerSecond => (double)this.Numerator / this.Denominator;
+
+    public static bool TryParse(string value, out FrameRate frameRate)
+    {
+        value = value.Trim();
+        if (value.Contains('/', StringComparison.Ordinal))
+        {
+            var parts = value.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length == 2 &&
+                int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var numerator) &&
+                int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var denominator) &&
+                denominator > 0)
+            {
+                frameRate = Normalize(numerator, denominator);
+                return true;
+            }
+        }
+        else if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var fps))
+        {
+            frameRate = FromDouble(fps);
+            return true;
+        }
+
+        frameRate = default;
+        return false;
+    }
+
+    public static FrameRate FromDouble(double fps)
+    {
+        var known = new (double fps, int n, int d)[]
+        {
+            (23.976, 24000, 1001),
+            (29.97, 30000, 1001),
+            (59.94, 60000, 1001),
+            (119.88, 120000, 1001),
+        };
+
+        foreach (var (knownFps, n, d) in known)
+        {
+            if (Math.Abs(fps - knownFps) < 0.001)
+            {
+                return new FrameRate(n, d);
+            }
+        }
+
+        var scaled = (int)Math.Round(fps * 1000.0, MidpointRounding.AwayFromZero);
+        var numerator = scaled;
+        var denominator = 1000;
+
+        if (numerator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(fps), "Frame rate must be positive.");
+        }
+
+        return Normalize(numerator, denominator);
+    }
+
+    private static FrameRate Normalize(int numerator, int denominator)
+    {
+        if (numerator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(numerator), "Numerator must be positive.");
+        }
+
+        if (denominator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(denominator), "Denominator must be positive.");
+        }
+
+        var gcd = GreatestCommonDivisor(Math.Abs(numerator), Math.Abs(denominator));
+        return new FrameRate(numerator / gcd, denominator / gcd);
+    }
+
+    private static int GreatestCommonDivisor(int a, int b)
+    {
+        while (b != 0)
+        {
+            var temp = b;
+            b = a % b;
+            a = temp;
+        }
+
+        return a;
+    }
+}

--- a/FramePacing/FrameRingBuffer.cs
+++ b/FramePacing/FrameRingBuffer.cs
@@ -1,0 +1,63 @@
+using System.Threading;
+
+namespace Tractus.HtmlToNdi.FramePacing;
+
+/// <summary>
+/// Single-producer single-consumer ring buffer that overwrites the oldest frames when full.
+/// </summary>
+/// <typeparam name="T">Value type stored in the buffer.</typeparam>
+public sealed class FrameRingBuffer<T>
+    where T : struct
+{
+    private readonly T[] buffer;
+    private long writeSequence = -1;
+    private long publishedSequence = -1;
+
+    public FrameRingBuffer(int capacity)
+    {
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be greater than zero.");
+        }
+
+        this.buffer = new T[capacity];
+    }
+
+    public int Capacity => this.buffer.Length;
+
+    public long LatestSequence => Volatile.Read(ref this.publishedSequence);
+
+    public void Push(T value)
+    {
+        var sequence = Interlocked.Increment(ref this.writeSequence);
+        this.buffer[(int)(sequence % this.buffer.Length)] = value;
+        Volatile.Write(ref this.publishedSequence, sequence);
+    }
+
+    public bool TryGetLatest(ref long lastSequence, out T value, out int dropped)
+    {
+        var latest = Volatile.Read(ref this.publishedSequence);
+        if (latest < 0 || latest == lastSequence)
+        {
+            value = default;
+            dropped = 0;
+            return false;
+        }
+
+        dropped = (int)Math.Max(0, latest - lastSequence - 1);
+        value = this.buffer[(int)(latest % this.buffer.Length)];
+        lastSequence = latest;
+        return true;
+    }
+
+    public int GetBacklog(long lastSequence)
+    {
+        var latest = Volatile.Read(ref this.publishedSequence);
+        if (latest < 0)
+        {
+            return 0;
+        }
+
+        return (int)Math.Min(this.buffer.Length, Math.Max(0, latest - lastSequence));
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -12,6 +12,7 @@ using Serilog;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Tractus.HtmlToNdi.Chromium;
+using Tractus.HtmlToNdi.FramePacing;
 using Tractus.HtmlToNdi.Models;
 
 namespace Tractus.HtmlToNdi;
@@ -19,6 +20,8 @@ public class Program
 {
     public static nint NdiSenderPtr;
     public static CefWrapper browserWrapper;
+    public static FrameRingBuffer<BrowserFrame>? VideoFrameBuffer;
+    public static FramePacer? VideoFramePacer;
 
     public static void Main(string[] args)
     {
@@ -122,6 +125,49 @@ public class Program
             }
         }
 
+        var bufferDepth = 5;
+        if (args.Any(x => x.StartsWith("--buffer-depth")))
+        {
+            try
+            {
+                bufferDepth = int.Parse(args.FirstOrDefault(x => x.StartsWith("--buffer-depth")).Split("=")[1]);
+
+                if (bufferDepth <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(bufferDepth));
+                }
+            }
+            catch (Exception)
+            {
+                Log.Error("Could not parse the --buffer-depth parameter. Exiting.");
+                return;
+            }
+        }
+
+        var frameRate = FrameRate.Default2997;
+        if (args.Any(x => x.StartsWith("--fps")))
+        {
+            try
+            {
+                var fpsValue = args.FirstOrDefault(x => x.StartsWith("--fps")).Split("=")[1];
+                if (!FrameRate.TryParse(fpsValue, out frameRate))
+                {
+                    throw new ArgumentException();
+                }
+            }
+            catch (Exception)
+            {
+                Log.Error("Could not parse the --fps parameter. Exiting.");
+                return;
+            }
+        }
+
+        var disableVsync = args.Any(x => string.Equals(x, "--disable-vsync", StringComparison.OrdinalIgnoreCase));
+        var disableFrameRateLimit = args.Any(x => string.Equals(x, "--disable-frame-rate-limit", StringComparison.OrdinalIgnoreCase));
+
+        var frameBuffer = new FrameRingBuffer<BrowserFrame>(bufferDepth);
+        VideoFrameBuffer = frameBuffer;
+
         AsyncContext.Run(async delegate
         {
             var settings = new CefSettings();
@@ -136,14 +182,23 @@ public class Program
             //settings.CefCommandLineArgs.Add("--in-process-gpu");
             //settings.SetOffScreenRenderingBestPerformanceArgs();
             settings.CefCommandLineArgs.Add("autoplay-policy", "no-user-gesture-required");
-            //settings.CefCommandLineArgs.Add("off-screen-frame-rate", "60");
-            //settings.CefCommandLineArgs.Add("disable-frame-rate-limit");
+            if (disableFrameRateLimit)
+            {
+                settings.CefCommandLineArgs.Add("disable-frame-rate-limit");
+            }
+
+            if (disableVsync)
+            {
+                settings.CefCommandLineArgs.Add("disable-gpu-vsync");
+            }
+
             settings.EnableAudio();
             Cef.Initialize(settings);
             browserWrapper = new CefWrapper(
                 width,
                 height,
-                startUrl);
+                startUrl,
+                frameBuffer);
 
             await browserWrapper.InitializeWrapperAsync();
         });
@@ -171,6 +226,37 @@ public class Program
         };
 
         Program.NdiSenderPtr = NDIlib.send_create(ref settings_T);
+
+        var pacerLogger = Log.ForContext<FramePacer>();
+        var framePacer = new FramePacer(
+            frameBuffer,
+            frameRate,
+            (frame, context) =>
+            {
+                if (Program.NdiSenderPtr == nint.Zero)
+                {
+                    return;
+                }
+
+                var videoFrame = new NDIlib.video_frame_v2_t()
+                {
+                    FourCC = NDIlib.FourCC_type_e.FourCC_type_BGRA,
+                    frame_rate_N = frameRate.Numerator,
+                    frame_rate_D = frameRate.Denominator,
+                    frame_format_type = NDIlib.frame_format_type_e.frame_format_type_progressive,
+                    line_stride_in_bytes = frame.Stride,
+                    picture_aspect_ratio = frame.AspectRatio,
+                    p_data = frame.BufferHandle,
+                    timecode = NDIlib.send_timecode_synthesize,
+                    xres = frame.Width,
+                    yres = frame.Height,
+                };
+
+                NDIlib.send_send_video_v2(Program.NdiSenderPtr, ref videoFrame);
+            },
+            pacerLogger);
+        framePacer.Start();
+        VideoFramePacer = framePacer;
 
         var capabilitiesXml = $$"""<ndi_capabilities ntk_kvm="true" />""";
         capabilitiesXml += "\0";
@@ -285,6 +371,24 @@ public class Program
 
         running = false;
         thread.Join();
+
+        var pacerMetrics = VideoFramePacer?.GetMetricsSnapshot();
+        VideoFramePacer?.Dispose();
+
+        if (pacerMetrics.HasValue)
+        {
+            var metrics = pacerMetrics.Value;
+            var avgIntervalText = metrics.AverageIntervalMilliseconds?.ToString("F3") ?? "n/a";
+            var avgLatencyText = metrics.AverageLatencyMilliseconds?.ToString("F3") ?? "n/a";
+            Log.Information(
+                "Frame pacing summary: sent {Sent} frames, repeats {Repeats}, drops {Drops}, avg interval {AverageInterval} ms, avg latency {AverageLatency} ms",
+                metrics.FramesSent,
+                metrics.RepeatedFrames,
+                metrics.DroppedFrames,
+                avgIntervalText,
+                avgLatencyText);
+        }
+
         browserWrapper.Dispose();
 
         if (Directory.Exists(launchCachePath))

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Tractus.HtmlToNdi.Tests")]

--- a/README.md
+++ b/README.md
@@ -15,10 +15,14 @@ If the web page you are loading has a transparent background, NDI will honor tha
 Parameter|Description
 ----|---
 `--ndiname="NDI Source Name"`|The source name this browser instance will send. Defaults to "`HTML5`".
-`--width=1920`|The width of the browser source. Defaults to `1920`.
-`--width=1080`|The height of the browser source. Defaults to `1080`.
+`--w=1920`|The width of the browser source. Defaults to `1920`.
+`--h=1080`|The height of the browser source. Defaults to `1080`.
 `--port=9999`|The port the HTTP server will listen on. Defaults to `9999`.
 `--url="https://www.tractus.ca"`|The startup webpage. Defaults to `https://testpattern.tractusevents.com/`.
+`--fps=29.97`|Target NDI frame rate. Accepts floating point values (e.g., `29.97`) or ratios (e.g., `30000/1001`). Defaults to `29.97` fps.
+`--buffer-depth=5`|Number of frames stored in the pacing buffer before the newest frame overwrites the oldest. Defaults to `5`.
+`--disable-vsync`|Adds the Chromium `--disable-gpu-vsync` flag during startup.
+`--disable-frame-rate-limit`|Adds the Chromium `--disable-frame-rate-limit` flag during startup.
 
 #### Example Launch
 
@@ -35,7 +39,7 @@ Route|Method|Description|Example
 - Frames are sent to NDI in RGBA format. Some machines may experience a slight performance penalty.
 - H.264 and any other non-free codecs are not available for video playback since this uses Chromium. Sites like YouTube likely won't work.
 - Audio data received from the browser is passed to NDI directly.
-- NDI frame rate is set to 60 frames per second. The internal max render frame rate is set to be capped at 60 frames per second.
+- Video is paced to 29.97 fps by default but both the NDI output rate and Chromium's internal frame rate cap are configurable via command-line switches.
 
 ## More Tools
 

--- a/Tractus.HtmlToNdi.Tests/FramePacing/FramePacerEngineTests.cs
+++ b/Tractus.HtmlToNdi.Tests/FramePacing/FramePacerEngineTests.cs
@@ -1,0 +1,88 @@
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Tractus.HtmlToNdi.FramePacing;
+using Xunit;
+
+namespace Tractus.HtmlToNdi.Tests.FramePacing;
+
+public class FramePacerEngineTests
+{
+    [Fact]
+    public void RingBufferReturnsLatestAndReportsDrops()
+    {
+        var buffer = new FrameRingBuffer<BrowserFrame>(3);
+        long sequence = -1;
+
+        for (var i = 0; i < 5; i++)
+        {
+            buffer.Push(new BrowserFrame(new nint(i + 1), 1920, 1080, 1920 * 4, 16f / 9f, DateTime.UtcNow.AddMilliseconds(i)));
+        }
+
+        Assert.Equal(3, buffer.GetBacklog(sequence));
+
+        var hasFrame = buffer.TryGetLatest(ref sequence, out var latest, out var dropped);
+
+        Assert.True(hasFrame);
+        Assert.Equal(4, dropped);
+        Assert.Equal(5, latest.BufferHandle.ToInt64());
+        Assert.Equal(0, buffer.GetBacklog(sequence));
+    }
+
+    [Fact]
+    public void EngineRepeatsAndDropsAsExpected()
+    {
+        var buffer = new FrameRingBuffer<BrowserFrame>(3);
+        var logger = new LoggerConfiguration().MinimumLevel.Debug().WriteTo.Sink(new NullSink()).CreateLogger();
+        var sent = new List<(BrowserFrame frame, FrameDeliveryContext context, DateTime tick)>();
+        var currentTick = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var engine = new FramePacerEngine(buffer, FrameRate.Default2997, (frame, context) =>
+        {
+            sent.Add((frame, context, currentTick));
+        },
+        logger);
+
+        var interval = engine.Interval;
+
+        var firstFrame = new BrowserFrame(new nint(1), 640, 360, 640 * 4, 16f / 9f, currentTick);
+        buffer.Push(firstFrame);
+
+        engine.ProcessTick(currentTick);
+        Assert.Single(sent);
+        Assert.False(sent[0].context.IsRepeat);
+        Assert.Equal(0, sent[0].context.DroppedFrames);
+
+        currentTick = currentTick.Add(interval);
+        engine.ProcessTick(currentTick);
+        Assert.Equal(2, sent.Count);
+        Assert.True(sent[1].context.IsRepeat);
+
+        var secondFrameCapture = currentTick.AddMilliseconds(-5);
+        var secondFrame = new BrowserFrame(new nint(2), 640, 360, 640 * 4, 16f / 9f, secondFrameCapture);
+        buffer.Push(secondFrame);
+
+        currentTick = currentTick.Add(interval);
+        engine.ProcessTick(currentTick);
+        Assert.Equal(3, sent.Count);
+        Assert.False(sent[2].context.IsRepeat);
+        Assert.Equal(0, sent[2].context.DroppedFrames);
+
+        buffer.Push(new BrowserFrame(new nint(3), 640, 360, 640 * 4, 16f / 9f, currentTick.AddMilliseconds(-2)));
+        buffer.Push(new BrowserFrame(new nint(4), 640, 360, 640 * 4, 16f / 9f, currentTick.AddMilliseconds(-1)));
+
+        currentTick = currentTick.Add(interval);
+        engine.ProcessTick(currentTick);
+
+        Assert.Equal(4, sent.Count);
+        Assert.False(sent[3].context.IsRepeat);
+        Assert.True(sent[3].context.DroppedFrames >= 1);
+    }
+
+    private sealed class NullSink : ILogEventSink
+    {
+        public void Emit(LogEvent logEvent)
+        {
+        }
+    }
+}

--- a/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
+++ b/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Serilog" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Tractus.HtmlToNdi.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tractus.HtmlToNdi.sln
+++ b/Tractus.HtmlToNdi.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.11.35303.130
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tractus.HtmlToNdi", "Tractus.HtmlToNdi.csproj", "{6B6C038D-3984-455A-95CA-A9079B3FC4E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tractus.HtmlToNdi.Tests", "Tractus.HtmlToNdi.Tests\Tractus.HtmlToNdi.Tests.csproj", "{BDABB725-B1D3-4A1D-AFEA-EF653D921C24}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,10 +20,18 @@ Global
 		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|x64.ActiveCfg = Debug|x64
 		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|x64.Build.0 = Debug|x64
 		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.ActiveCfg = Release|x64
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.Build.0 = Release|x64
-	EndGlobalSection
+                {6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.Build.0 = Release|Any CPU
+                {6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.ActiveCfg = Release|x64
+                {6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.Build.0 = Release|x64
+                {BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Debug|x64.Build.0 = Debug|Any CPU
+                {BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Release|Any CPU.Build.0 = Release|Any CPU
+                {BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Release|x64.ActiveCfg = Release|Any CPU
+                {BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Release|x64.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- introduce a BrowserFrame ring buffer and pacing thread so Chromium paints are decoupled from NDI send timing
- add CLI options for FPS, buffer depth, and optional vsync/frame-rate-limit flags while emitting pacing telemetry
- create an xUnit test project that exercises the ring buffer and pacing logic plus update contributor/docs to describe the new flow

## Testing
- dotnet test *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da25763f448329ae00c87d15e52fbc