### PR TITLE
Implement ring-buffer-based frame pacer for smoother video output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 # AGENTS.md — Project briefing for Tractus.HtmlToNdi
 
-> Repository: [`tractusevents/Tractus.HtmlToNdi`](https://github.com/tractusevents/Tractus.HtmlToNdi)  
-> Purpose: Windows-only utility that renders a Chromium page off-screen and publishes video/audio plus limited KVM over the NDI protocol, with a minimal HTTP control API.
+> Repository: [`tractusevents/Tractus.HtmlToNdi`](https://github.com/tractusevents/Tractus.HtmlToNdi)
+> Purpose: Windows-only utility that renders a Chromium page off-screen and publishes video/audio plus limited KVM over the NDI
+protocol, with a minimal HTTP control API.
 
 This document is the ground-truth orientation guide. Treat it as a living spec—update it whenever behaviour changes.
 
@@ -9,13 +10,14 @@ This document is the ground-truth orientation guide. Treat it as a living spec�
 
 ## 1. What the current build actually does (net8.0, December 2024 snapshot)
 
-* Entry point: `Program.Main` (`Program.cs`). It sets the working directory, initializes logging via `AppManagement.Initialize`, parses CLI flags, starts CefSharp OffScreen inside a dedicated synchronization context, creates the singleton `CefWrapper`, spins up the ASP.NET Core minimal API, and allocates a single NDI sender.
-* Chromium lifecycle: `AsyncContext.Run` + `SingleThreadSynchronizationContext` keep CefSharp happy on one STA-like thread. `CefWrapper.InitializeWrapperAsync` waits for the first page load, locks the windowless frame rate to 60 fps, unmutes audio (CEF starts muted), subscribes to the `Paint` event, and starts a watchdog thread that invalidates the view if Chromium goes silent for ≥1 s.
-* Video path: every `ChromiumWebBrowser.Paint` callback builds an `NDIlib.video_frame_v2_t` with BGRA pixels, `frame_rate_N=60`, `frame_rate_D=1`, progressive flag, and forwards the GPU buffer handle to `NDIlib.send_send_video_v2`. There is no CPU copy, colour conversion, or double buffering.
+* Entry point: `Program.Main` (`Program.cs`). It sets the working directory, initializes logging via `AppManagement.Initialize`,
+  parses CLI flags, starts CefSharp OffScreen inside a dedicated synchronization context, creates the singleton `CefWrapper`, spins up the ASP.NET Core minimal API, and allocates a single NDI sender.
+* Chromium lifecycle: `AsyncContext.Run` + `SingleThreadSynchronizationContext` keep CefSharp happy on one STA-like thread. `CefWrapper.InitializeWrapperAsync` waits for the first page load, configures Chromium's windowless frame rate, unmutes audio (CEF starts muted), subscribes to the `Paint` event, starts a watchdog thread that invalidates the view if Chromium goes silent for ≥1 s, and then launches the video pacing thread.
+* Video path: each `ChromiumWebBrowser.Paint` callback copies the BGRA pixels out of Chromium's GPU buffer into a managed `BrowserFrame` stored in a single-producer/single-consumer ring buffer. A dedicated pacing thread wakes at the configured cadence (default 29.97 fps, `30000/1001`), pulls the newest frame, drops stale ones, and calls `NDIlib.send_send_video_v2`. When Chromium stalls, the pacer repeats the most recent frame to keep the clock steady.
 * Audio path: `CustomAudioHandler` exposes Cef audio, allocates a float buffer sized for one second, copies each planar channel into contiguous blocks inside that buffer, and sends it with `NDIlib.send_send_audio_v2`. (Note: the code claims “interleaved” but still stores channels sequentially; downstream receivers must cope with planar-like layout.)
 * Control plane: ASP.NET Core minimal API listens on HTTP (no TLS, no auth). Swagger UI is enabled. All endpoints directly call methods on the static `Program.browserWrapper` instance.
 * KVM metadata: the app advertises `<ndi_capabilities ntk_kvm="true" />` and starts a background thread that polls `NDIlib.send_capture` every second. It interprets `<ndi_kvm ...>` metadata frames, caching normalized mouse coordinates on opcode `0x03` and triggering a left click on opcode `0x04`.
-* Shutdown: after `app.Run()` returns, the metadata thread is stopped, the browser wrapper is disposed, and the temporary Cef cache (`cache/<guid>`) is deleted.
+* Shutdown: after `app.Run()` returns, the metadata thread is stopped, the browser wrapper is disposed (which stops the pacing thread and tears down the ring buffer), and the temporary Cef cache (`cache/<guid>`) is deleted.
 
 ---
 
@@ -30,6 +32,10 @@ This document is the ground-truth orientation guide. Treat it as a living spec�
 | `--url=<https://...>` | `--url=https://testpattern.tractusevents.com/` | Sets the startup page. Defaults to `https://testpattern.tractusevents.com/`. |
 | `--w=<int>` | `--w=1920` | Sets browser width in pixels. Defaults to 1920. |
 | `--h=<int>` | `--h=1080` | Sets browser height in pixels. Defaults to 1080. |
+| `--fps=<value>` | `--fps=29.97` | Sets the paced NDI output frame rate. Accepts floating-point values (e.g., `29.97`) or ratios (e.g., `30000/1001`). Defaults to 29.97 fps. |
+| `--buffer-depth=<int>` | `--buffer-depth=5` | Sets the number of frames stored in the pacing ring buffer before overwriting. Defaults to 5. |
+| `--disable-vsync` | `--disable-vsync` | Adds Chromium's `--disable-gpu-vsync` flag when launching CEF. |
+| `--disable-frame-rate-limit` | `--disable-frame-rate-limit` | Adds Chromium's `--disable-frame-rate-limit` flag when launching CEF. |
 | `-debug` | `-debug` | Raises Serilog minimum level to `Debug`. |
 | `-quiet` | `-quiet` | Disables console logging (file logging remains). |
 
@@ -49,13 +55,24 @@ Other configuration surfaces:
   CefWrapper.cs                       # Owns ChromiumWebBrowser instance, paint-to-NDI bridge, HTTP input helpers
   CustomAudioHandler.cs               # IAudioHandler implementation, planar float → contiguous buffer → NDI audio
   SingleThreadSynchronizationContext.cs # BlockingCollection-backed synchronization context
+/FramePacing/
+  BrowserFrame.cs                     # Immutable value type holding BGRA pixel buffers from Chromium
+  FrameDeliveryContext.cs             # Metadata describing repeats, drops, latency, backlog
+  FramePacer.cs                       # Worker thread that ticks at the target FPS
+  FramePacerEngine.cs                 # Core pacing logic (interval tracking, metrics, send invocation)
+  FramePacerMetrics.cs                # Snapshot used for shutdown logging/diagnostics
+  FrameRate.cs                        # Parsing helpers for decimal and ratio FPS inputs
+  FrameRingBuffer.cs                  # Single-producer/single-consumer ring buffer with overwrite semantics
 /Models/
   GoToUrlModel.cs                     # DTOs for `/seturl` and `/keystroke`
 AppManagement.cs                      # Logging bootstrap, per-app data helpers, CLI flags (-debug/-quiet)
 Program.cs                            # Main: CLI parsing, Cef initialization, HTTP API, NDI sender, KVM thread
+README.md                             # End-user documentation (keep in sync with API/CLI)
 Tractus.HtmlToNdi.csproj              # net8.0 exe, package references (CefSharp OffScreen, Serilog, Swashbuckle, NDILib)
 Tractus.HtmlToNdi.http                # Sample HTTP requests for manual testing (update alongside API changes)
-README.md                             # End-user documentation (currently missing some routes—keep in sync when editing)
+/Tests/Tractus.HtmlToNdi.Tests/
+  FramePacing/FramePacerEngineTests.cs # Unit tests for ring buffer + pacing engine
+  Tractus.HtmlToNdi.Tests.csproj       # xUnit test project (net8.0)
 ```
 
 There are no nested `AGENTS.md` files; this document covers the entire repository.
@@ -72,17 +89,18 @@ Main
  │    ├─ Configure Serilog sinks (console + Documents/<AppName>_log.txt)
  │    └─ Respect -debug / -quiet flags
  ├─ Prompt/parse CLI flags (see §2)
+ ├─ Create BrowserFrame ring buffer + FramePacer according to CLI options
  ├─ AsyncContext.Run(async)
- │    ├─ Configure CefSettings (RootCachePath=cache/<guid>, autoplay-policy override, EnableAudio)
+ │    ├─ Configure CefSettings (RootCachePath=cache/<guid>, autoplay-policy override, optional vsync/fps flags)
  │    ├─ Cef.Initialize(settings)
- │    └─ Instantiate CefWrapper(width, height, url) and await InitializeWrapperAsync()
+ │    └─ Instantiate CefWrapper(width, height, url, pacing options) and await InitializeWrapperAsync()
  ├─ Build WebApplication (Serilog integration, Swagger, authorization middleware added but unused)
  ├─ Create NDI sender (NDIlib.send_create)
  │    ├─ Advertise `<ndi_capabilities ntk_kvm="true" />`
  │    └─ Launch background thread polling NDI metadata (1 s timeout)
  ├─ Map HTTP routes directly to CefWrapper methods
- ├─ app.Run()   # blocks until shutdown
- ├─ On shutdown: stop metadata thread, dispose CefWrapper
+ ├─ app.Run()   # blocks until shutdown while FramePacer thread keeps emitting video
+ ├─ On shutdown: stop metadata thread, dispose CefWrapper (which stops the pacer + ring buffer)
  └─ Delete temporary Cef cache directory (best-effort)
 ```
 
@@ -114,10 +132,16 @@ When adding routes, update **both** this table and `Tractus.HtmlToNdi.http` samp
 ### CefWrapper (`Chromium/CefWrapper.cs`)
 * `ChromiumWebBrowser` is constructed with `AudioHandler = new CustomAudioHandler()` and a fixed `System.Drawing.Size(width,height)`.
 * `RenderWatchdog` thread invalidates the view once per second if no `Paint` events arrive, preventing NDI receivers from freezing on static pages.
+* `OnBrowserPaint` copies the BGRA surface into a managed buffer, pushes it into the ring buffer, and immediately returns to Chromium; the pacing thread performs all NDI sends.
 * `ScrollBy` always uses `(x=0,y=0)` as the mouse location; complex scrolling (e.g., inside scrolled divs) may require additional API work.
 * `Click` only supports the left mouse button; drag, double-click, or right-click interactions are not implemented.
 * `SendKeystrokes` issues **only** `KeyDown` events with `NativeKeyCode=Convert.ToInt32(char)`. There is no key-up, modifiers, or IME support—uppercase letters require the page to handle them despite missing Shift state.
-* `Dispose` detaches the `Paint` handler and disposes the browser, but still has TODO comments for unmanaged cleanup.
+* `Dispose` detaches the `Paint` handler, stops the pacer, disposes the ring buffer, and then disposes the browser.
+
+### Frame pacing (`FramePacing/*`)
+* `FrameRingBuffer<T>` implements a lock-free single-producer/single-consumer buffer with overwrite semantics.
+* `FramePacerEngine` tracks render cadence, backlog, and latency; it repeats frames when Chromium is quiet and reports drop counts when bursts occur.
+* `FramePacer.GetMetricsSnapshot()` returns aggregated statistics logged once at shutdown.
 
 ### CustomAudioHandler (`Chromium/CustomAudioHandler.cs`)
 * `ChannelLayoutToChannelCount` covers most layouts but returns 0 for unsupported ones, causing `GetAudioParameters` to fail (muting audio).
@@ -125,7 +149,7 @@ When adding routes, update **both** this table and `Tractus.HtmlToNdi.http` samp
 * Memory is manually allocated/freed via `Marshal.AllocHGlobal` / `FreeHGlobal`. Failing to call `Dispose` will leak unmanaged memory.
 
 ### NDI integration (`Program.cs`)
-* `Program.NdiSenderPtr` must remain valid for the lifetime of the process; there is currently **no** call to `NDIlib.send_destroy`. Adding explicit teardown requires guarding against `nint.Zero` in paint/audio handlers.
+* `Program.NdiSenderPtr` must remain valid for the lifetime of the process; there is currently **no** call to `NDIlib.send_destroy`. Adding explicit teardown requires guarding against `nint.Zero` in pacing callbacks and audio handlers.
 * Metadata loop logs every metadata frame at `Warning` level (`Log.Logger.Warning("Got metadata: ...")`), which can flood logs if receivers send frequent updates.
 * Only opcodes `0x03` (mouse move) and `0x04` (left click) are handled; `0x07` (mouse up) is ignored intentionally. There is no translation for scroll, keyboard, or multi-button events.
 
@@ -142,8 +166,9 @@ When adding routes, update **both** this table and `Tractus.HtmlToNdi.http` samp
 3. **Input fidelity gaps**: No key-up events, modifiers, IME, or right/middle mouse buttons. `/scroll` ignores pointer position. Drag-and-drop is unsupported.
 4. **Codec constraints**: Standard Chromium build without proprietary codecs—DRM/H.264/YouTube may fail.
 5. **Audio layout**: Output buffer is not truly interleaved despite metadata suggesting so, which may confuse strict NDI consumers.
-6. **Resource cleanup**: NDI sender and Cef global state are not explicitly disposed/destroyed; rely on process exit. Abrupt termination can leave cache folders under `cache/`.
-7. **Logging noise**: All incoming KVM metadata is logged at warning level, which may clutter logs under active control.
+6. **CPU copies for video**: Frame pacing requires copying Chromium buffers into managed memory each paint; high resolutions can incur GC pressure.
+7. **Resource cleanup**: NDI sender and Cef global state are not explicitly destroyed; rely on process exit. Abrupt termination can leave cache folders under `cache/`.
+8. **Logging noise**: All incoming KVM metadata is logged at warning level, which may clutter logs under active control.
 
 ---
 
@@ -153,15 +178,15 @@ When adding routes, update **both** this table and `Tractus.HtmlToNdi.http` samp
 2. **Runtime configuration endpoints** – `/size`, `/fps`, `/audio` toggles that safely recreate the Chromium instance and reconfigure NDI frames.
 3. **Improved input/KVM parity** – handle drag (distinct down/up), right-click, mouse move via HTTP, keyboard modifiers, and translate additional NDI KVM opcodes.
 4. **Audio correctness** – produce genuinely interleaved buffers (or update metadata) and expose sample-rate/channel status via diagnostics.
-5. **Observability** – add `/stats` endpoint exposing render cadence, last paint timestamp, audio packet counts, and cache path.
-6. **Graceful shutdown** – explicitly destroy the NDI sender, call `Cef.Shutdown()`, and ensure watchdog thread stops before disposing.
+5. **Observability** – add `/stats` endpoint exposing render cadence, last paint timestamp, audio packet counts, cache path, and pacing metrics.
+6. **Graceful shutdown** – explicitly destroy the NDI sender, call `Cef.Shutdown()`, and ensure watchdog & pacing threads stop before disposing.
 
 ---
 
 ## 9. Validation checklist (run manually after significant changes)
 
 * ✅ Verify transparency by loading `https://testpattern.tractusevents.com/` and checking alpha in an NDI receiver.
-* ✅ Stress-test animation (e.g., WebGL or CSS animation) and confirm frame cadence ~16.6 ms (60 fps) without dropped frames.
+* ✅ Stress-test animation (e.g., WebGL or CSS animation) and confirm paced NDI cadence matches the configured rate (29.97 fps by default) without sustained dropped frames.
 * ✅ Play an audio source with known stereo content and ensure both channels arrive with correct timing.
 * ✅ Exercise every HTTP route via `Tractus.HtmlToNdi.http` or Swagger (set URL, scroll, click, type, refresh) and watch logs for errors.
 * ✅ Confirm KVM metadata click-from-receiver works (e.g., NewTek Studio Monitor sending mouse move + click).
@@ -173,8 +198,8 @@ When adding routes, update **both** this table and `Tractus.HtmlToNdi.http` samp
 
 * Stick to the single-instance assumption unless refactoring `Program` comprehensively; many helpers assume globals.
 * Respect the CefSharp threading rules—initialization must continue to use `AsyncContext`/`SingleThreadSynchronizationContext`.
-* When touching HTTP routes, update Swagger annotations (minimal API `.WithOpenApi()`) and documentation (`README.md`, `Tractus.HtmlToNdi.http`, and this file).
-* If modifying audio/video frame structures, review `CustomAudioHandler` and `CefWrapper.OnBrowserPaint` together to keep NDI metadata consistent.
+* When touching HTTP routes, update Swagger annotations (minimal API `.WithOpenApi()`), documentation (`README.md`, `Tractus.HtmlToNdi.http`), and this file.
+* If modifying audio/video frame structures, review `CustomAudioHandler`, the frame ring buffer, and the pacer together to keep NDI metadata consistent.
 * Before merging, ensure Serilog messages remain informative (prefer structured logging over string concatenation where practical).
 
 ---

--- a/FramePacing/BrowserFrame.cs
+++ b/FramePacing/BrowserFrame.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Tractus.HtmlToNdi.FramePacing;
+
+/// <summary>
+/// Represents a frame produced by the Chromium renderer.
+/// </summary>
+public readonly record struct BrowserFrame(
+    byte[] PixelBuffer,
+    int Width,
+    int Height,
+    int Stride,
+    float AspectRatio,
+    DateTime CapturedAt)
+{
+    public bool HasBuffer => this.PixelBuffer is { Length: > 0 };
+}

--- a/FramePacing/FrameDeliveryContext.cs
+++ b/FramePacing/FrameDeliveryContext.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Tractus.HtmlToNdi.FramePacing;
+
+/// <summary>
+/// Provides context for a paced frame send.
+/// </summary>
+public readonly record struct FrameDeliveryContext(
+    bool IsRepeat,
+    int DroppedFrames,
+    TimeSpan Latency,
+    int Backlog);

--- a/FramePacing/FramePacer.cs
+++ b/FramePacing/FramePacer.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Tractus.HtmlToNdi.FramePacing;
+
+public sealed class FramePacer : IDisposable
+{
+    private readonly FramePacerEngine engine;
+    private readonly CancellationTokenSource cancellationTokenSource = new();
+    private Thread? workerThread;
+    private bool disposed;
+
+    public FramePacer(FramePacerEngine engine)
+    {
+        this.engine = engine;
+    }
+
+    public FramePacer(FrameRingBuffer<BrowserFrame> buffer, FrameRate frameRate, Action<BrowserFrame, FrameDeliveryContext> sendFrame, Serilog.ILogger logger)
+        : this(new FramePacerEngine(buffer, frameRate, sendFrame, logger))
+    {
+    }
+
+    public FrameRate FrameRate => this.engine.FrameRate;
+
+    public void Start()
+    {
+        if (this.workerThread != null)
+        {
+            return;
+        }
+
+        this.workerThread = new Thread(this.RunLoop)
+        {
+            IsBackground = true,
+            Name = "FramePacer",
+            Priority = ThreadPriority.AboveNormal,
+        };
+        this.workerThread.Start();
+    }
+
+    public FramePacerMetrics GetMetricsSnapshot() => this.engine.GetMetricsSnapshot();
+
+    private void RunLoop()
+    {
+        var token = this.cancellationTokenSource.Token;
+        var interval = this.engine.Interval;
+        var stopwatch = Stopwatch.StartNew();
+        var nextTick = stopwatch.Elapsed;
+
+        while (!token.IsCancellationRequested)
+        {
+            var remaining = nextTick - stopwatch.Elapsed;
+            if (remaining > TimeSpan.Zero)
+            {
+                if (remaining > TimeSpan.FromMilliseconds(2))
+                {
+                    Thread.Sleep(remaining - TimeSpan.FromMilliseconds(1));
+                }
+                else
+                {
+                    SpinWait.SpinUntil(() => stopwatch.Elapsed >= nextTick || token.IsCancellationRequested, remaining);
+                }
+            }
+            else
+            {
+                nextTick = stopwatch.Elapsed;
+            }
+
+            if (token.IsCancellationRequested)
+            {
+                break;
+            }
+
+            this.engine.ProcessTick(DateTime.UtcNow);
+            nextTick += interval;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (this.disposed)
+        {
+            return;
+        }
+
+        this.cancellationTokenSource.Cancel();
+        this.workerThread?.Join();
+        this.workerThread = null;
+        this.cancellationTokenSource.Dispose();
+        this.disposed = true;
+    }
+}

--- a/FramePacing/FramePacerEngine.cs
+++ b/FramePacing/FramePacerEngine.cs
@@ -1,0 +1,285 @@
+using System;
+using Serilog;
+
+namespace Tractus.HtmlToNdi.FramePacing;
+
+internal sealed class FramePacerEngine
+{
+    private static readonly TimeSpan MetricsLogInterval = TimeSpan.FromSeconds(1);
+
+    private readonly FrameRingBuffer<BrowserFrame> buffer;
+    private readonly Action<BrowserFrame, FrameDeliveryContext> sendFrame;
+    private readonly ILogger logger;
+
+    private readonly TimeSpan interval;
+
+    private BrowserFrame? lastFrame;
+    private long lastSequence = -1;
+    private DateTime? lastTickTime;
+    private DateTime lastMetricsLog = DateTime.MinValue;
+
+    private long totalFramesSent;
+    private long totalRepeats;
+    private long totalDrops;
+
+    private TimeSpan totalIntervalSum = TimeSpan.Zero;
+    private long totalIntervalCount;
+    private TimeSpan totalIntervalMin = TimeSpan.MaxValue;
+    private TimeSpan totalIntervalMax = TimeSpan.Zero;
+
+    private TimeSpan totalLatencySum = TimeSpan.Zero;
+    private long totalLatencyCount;
+    private TimeSpan totalLatencyMin = TimeSpan.MaxValue;
+    private TimeSpan totalLatencyMax = TimeSpan.Zero;
+
+    private TimeSpan logIntervalSum = TimeSpan.Zero;
+    private long logIntervalCount;
+    private TimeSpan logIntervalMin = TimeSpan.MaxValue;
+    private TimeSpan logIntervalMax = TimeSpan.Zero;
+
+    private TimeSpan logLatencySum = TimeSpan.Zero;
+    private long logLatencyCount;
+    private TimeSpan logLatencyMin = TimeSpan.MaxValue;
+    private TimeSpan logLatencyMax = TimeSpan.Zero;
+
+    private long logRepeats;
+    private long logDrops;
+
+    public FramePacerEngine(
+        FrameRingBuffer<BrowserFrame> buffer,
+        FrameRate frameRate,
+        Action<BrowserFrame, FrameDeliveryContext> sendFrame,
+        ILogger logger)
+    {
+        this.buffer = buffer;
+        this.FrameRate = frameRate;
+        this.interval = TimeSpan.FromSeconds(frameRate.Denominator / (double)frameRate.Numerator);
+        this.sendFrame = sendFrame;
+        this.logger = logger;
+    }
+
+    public FrameRate FrameRate { get; }
+
+    public TimeSpan Interval => this.interval;
+
+    public void ProcessTick(DateTime tickTime)
+    {
+        var backlog = this.buffer.GetBacklog(this.lastSequence);
+        this.UpdateIntervalStats(tickTime);
+
+        var sentFrame = false;
+        var repeated = false;
+
+        if (this.buffer.TryGetLatest(ref this.lastSequence, out var frame, out var dropped))
+        {
+            this.lastFrame = frame;
+            this.totalDrops += dropped;
+            this.logDrops += dropped;
+
+            var latency = tickTime - frame.CapturedAt;
+            this.RecordLatency(latency);
+
+            this.InvokeSend(frame, new FrameDeliveryContext(false, dropped, latency, backlog));
+            sentFrame = true;
+        }
+        else if (this.lastFrame.HasValue)
+        {
+            var frameToRepeat = this.lastFrame.Value;
+            var latency = tickTime - frameToRepeat.CapturedAt;
+            this.InvokeSend(frameToRepeat, new FrameDeliveryContext(true, 0, latency, backlog));
+            this.totalRepeats++;
+            this.logRepeats++;
+            sentFrame = true;
+            repeated = true;
+        }
+
+        if (sentFrame)
+        {
+            this.totalFramesSent++;
+        }
+
+        this.MaybeLog(tickTime, backlog, repeated);
+    }
+
+    public FramePacerMetrics GetMetricsSnapshot()
+    {
+        double? avgInterval = this.totalIntervalCount > 0
+            ? this.totalIntervalSum.TotalMilliseconds / this.totalIntervalCount
+            : null;
+        double? minInterval = this.totalIntervalCount > 0 && this.totalIntervalMin != TimeSpan.MaxValue
+            ? this.totalIntervalMin.TotalMilliseconds
+            : null;
+        double? maxInterval = this.totalIntervalCount > 0 && this.totalIntervalMax != TimeSpan.Zero
+            ? this.totalIntervalMax.TotalMilliseconds
+            : null;
+
+        double? avgLatency = this.totalLatencyCount > 0
+            ? this.totalLatencySum.TotalMilliseconds / this.totalLatencyCount
+            : null;
+        double? minLatency = this.totalLatencyCount > 0 && this.totalLatencyMin != TimeSpan.MaxValue
+            ? this.totalLatencyMin.TotalMilliseconds
+            : null;
+        double? maxLatency = this.totalLatencyCount > 0 && this.totalLatencyMax != TimeSpan.Zero
+            ? this.totalLatencyMax.TotalMilliseconds
+            : null;
+
+        return new FramePacerMetrics(
+            this.totalFramesSent,
+            this.totalRepeats,
+            this.totalDrops,
+            avgInterval,
+            minInterval,
+            maxInterval,
+            avgLatency,
+            minLatency,
+            maxLatency,
+            this.FrameRate.FramesPerSecond,
+            this.buffer.Capacity);
+    }
+
+    private void UpdateIntervalStats(DateTime tickTime)
+    {
+        if (this.lastTickTime.HasValue)
+        {
+            var delta = tickTime - this.lastTickTime.Value;
+            if (delta < TimeSpan.Zero)
+            {
+                delta = TimeSpan.Zero;
+            }
+
+            this.totalIntervalSum += delta;
+            this.totalIntervalCount++;
+            if (delta < this.totalIntervalMin)
+            {
+                this.totalIntervalMin = delta;
+            }
+
+            if (delta > this.totalIntervalMax)
+            {
+                this.totalIntervalMax = delta;
+            }
+
+            this.logIntervalSum += delta;
+            this.logIntervalCount++;
+            if (delta < this.logIntervalMin)
+            {
+                this.logIntervalMin = delta;
+            }
+
+            if (delta > this.logIntervalMax)
+            {
+                this.logIntervalMax = delta;
+            }
+        }
+
+        this.lastTickTime = tickTime;
+    }
+
+    private void RecordLatency(TimeSpan latency)
+    {
+        if (latency < TimeSpan.Zero)
+        {
+            latency = TimeSpan.Zero;
+        }
+
+        this.totalLatencySum += latency;
+        this.totalLatencyCount++;
+        if (latency < this.totalLatencyMin)
+        {
+            this.totalLatencyMin = latency;
+        }
+
+        if (latency > this.totalLatencyMax)
+        {
+            this.totalLatencyMax = latency;
+        }
+
+        this.logLatencySum += latency;
+        this.logLatencyCount++;
+        if (latency < this.logLatencyMin)
+        {
+            this.logLatencyMin = latency;
+        }
+
+        if (latency > this.logLatencyMax)
+        {
+            this.logLatencyMax = latency;
+        }
+    }
+
+    private void MaybeLog(DateTime tickTime, int backlog, bool repeated)
+    {
+        if ((tickTime - this.lastMetricsLog) < MetricsLogInterval)
+        {
+            return;
+        }
+
+        if (this.logIntervalCount == 0 && this.logLatencyCount == 0 && this.logDrops == 0 && this.logRepeats == 0)
+        {
+            this.lastMetricsLog = tickTime;
+            return;
+        }
+
+        var avgInterval = this.logIntervalCount > 0
+            ? this.logIntervalSum.TotalMilliseconds / this.logIntervalCount
+            : (double?)null;
+        var minInterval = this.logIntervalCount > 0 && this.logIntervalMin != TimeSpan.MaxValue
+            ? this.logIntervalMin.TotalMilliseconds
+            : (double?)null;
+        var maxInterval = this.logIntervalCount > 0 && this.logIntervalMax != TimeSpan.Zero
+            ? this.logIntervalMax.TotalMilliseconds
+            : (double?)null;
+
+        var avgLatency = this.logLatencyCount > 0
+            ? this.logLatencySum.TotalMilliseconds / this.logLatencyCount
+            : (double?)null;
+        var minLatency = this.logLatencyCount > 0 && this.logLatencyMin != TimeSpan.MaxValue
+            ? this.logLatencyMin.TotalMilliseconds
+            : (double?)null;
+        var maxLatency = this.logLatencyCount > 0 && this.logLatencyMax != TimeSpan.Zero
+            ? this.logLatencyMax.TotalMilliseconds
+            : (double?)null;
+
+        this.logger.Debug("Frame pacer stats: target {TargetFps:F3} fps, avg interval {AverageInterval} ms (min {MinInterval} / max {MaxInterval}), avg latency {AverageLatency} ms, repeats {Repeats}, drops {Drops}, backlog {Backlog}, lastRepeat {LastRepeat}",
+            this.FrameRate.FramesPerSecond,
+            avgInterval,
+            minInterval,
+            maxInterval,
+            avgLatency,
+            this.logRepeats,
+            this.logDrops,
+            backlog,
+            repeated);
+
+        this.logIntervalSum = TimeSpan.Zero;
+        this.logIntervalCount = 0;
+        this.logIntervalMin = TimeSpan.MaxValue;
+        this.logIntervalMax = TimeSpan.Zero;
+
+        this.logLatencySum = TimeSpan.Zero;
+        this.logLatencyCount = 0;
+        this.logLatencyMin = TimeSpan.MaxValue;
+        this.logLatencyMax = TimeSpan.Zero;
+
+        this.logRepeats = 0;
+        this.logDrops = 0;
+        this.lastMetricsLog = tickTime;
+    }
+
+    private void InvokeSend(BrowserFrame frame, FrameDeliveryContext context)
+    {
+        if (!frame.HasBuffer)
+        {
+            return;
+        }
+
+        try
+        {
+            this.sendFrame(frame, context);
+        }
+        catch (Exception ex)
+        {
+            this.logger.Error(ex, "Frame send failed");
+        }
+    }
+}

--- a/FramePacing/FramePacerMetrics.cs
+++ b/FramePacing/FramePacerMetrics.cs
@@ -1,0 +1,14 @@
+namespace Tractus.HtmlToNdi.FramePacing;
+
+public readonly record struct FramePacerMetrics(
+    long FramesSent,
+    long RepeatedFrames,
+    long DroppedFrames,
+    double? AverageIntervalMilliseconds,
+    double? MinIntervalMilliseconds,
+    double? MaxIntervalMilliseconds,
+    double? AverageLatencyMilliseconds,
+    double? MinLatencyMilliseconds,
+    double? MaxLatencyMilliseconds,
+    double TargetFps,
+    int BufferCapacity);

--- a/FramePacing/FrameRate.cs
+++ b/FramePacing/FrameRate.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Globalization;
+
+namespace Tractus.HtmlToNdi.FramePacing;
+
+public readonly record struct FrameRate(int Numerator, int Denominator)
+{
+    public static FrameRate Default2997 { get; } = new FrameRate(30000, 1001);
+
+    public double FramesPerSecond => (double)this.Numerator / this.Denominator;
+
+    public static bool TryParse(string value, out FrameRate frameRate)
+    {
+        value = value.Trim();
+        if (value.Contains('/', StringComparison.Ordinal))
+        {
+            var parts = value.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length == 2 &&
+                int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var numerator) &&
+                int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var denominator) &&
+                denominator > 0)
+            {
+                frameRate = Normalize(numerator, denominator);
+                return true;
+            }
+        }
+        else if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var fps))
+        {
+            frameRate = FromDouble(fps);
+            return true;
+        }
+
+        frameRate = default;
+        return false;
+    }
+
+    public static FrameRate FromDouble(double fps)
+    {
+        var known = new (double fps, int n, int d)[]
+        {
+            (23.976, 24000, 1001),
+            (29.97, 30000, 1001),
+            (59.94, 60000, 1001),
+            (119.88, 120000, 1001),
+        };
+
+        foreach (var (knownFps, n, d) in known)
+        {
+            if (Math.Abs(fps - knownFps) < 0.001)
+            {
+                return new FrameRate(n, d);
+            }
+        }
+
+        var scaled = (int)Math.Round(fps * 1000.0, MidpointRounding.AwayFromZero);
+        var numerator = scaled;
+        var denominator = 1000;
+
+        if (numerator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(fps), "Frame rate must be positive.");
+        }
+
+        return Normalize(numerator, denominator);
+    }
+
+    private static FrameRate Normalize(int numerator, int denominator)
+    {
+        if (numerator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(numerator), "Numerator must be positive.");
+        }
+
+        if (denominator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(denominator), "Denominator must be positive.");
+        }
+
+        var gcd = GreatestCommonDivisor(Math.Abs(numerator), Math.Abs(denominator));
+        return new FrameRate(numerator / gcd, denominator / gcd);
+    }
+
+    private static int GreatestCommonDivisor(int a, int b)
+    {
+        while (b != 0)
+        {
+            var temp = b;
+            b = a % b;
+            a = temp;
+        }
+
+        return a;
+    }
+}

--- a/FramePacing/FrameRingBuffer.cs
+++ b/FramePacing/FrameRingBuffer.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading;
+
+namespace Tractus.HtmlToNdi.FramePacing;
+
+/// <summary>
+/// Single-producer single-consumer ring buffer that overwrites the oldest frames when full.
+/// </summary>
+/// <typeparam name="T">Value type stored in the buffer.</typeparam>
+public sealed class FrameRingBuffer<T>
+    where T : struct
+{
+    private readonly T[] buffer;
+    private long writeSequence = -1;
+    private long publishedSequence = -1;
+
+    public FrameRingBuffer(int capacity)
+    {
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be greater than zero.");
+        }
+
+        this.buffer = new T[capacity];
+    }
+
+    public int Capacity => this.buffer.Length;
+
+    public long LatestSequence => Volatile.Read(ref this.publishedSequence);
+
+    public void Push(T value)
+    {
+        var sequence = Interlocked.Increment(ref this.writeSequence);
+        this.buffer[(int)(sequence % this.buffer.Length)] = value;
+        Volatile.Write(ref this.publishedSequence, sequence);
+    }
+
+    public bool TryGetLatest(ref long lastSequence, out T value, out int dropped)
+    {
+        var latest = Volatile.Read(ref this.publishedSequence);
+        if (latest < 0 || latest == lastSequence)
+        {
+            value = default;
+            dropped = 0;
+            return false;
+        }
+
+        dropped = (int)Math.Max(0, latest - lastSequence - 1);
+        value = this.buffer[(int)(latest % this.buffer.Length)];
+        lastSequence = latest;
+        return true;
+    }
+
+    public int GetBacklog(long lastSequence)
+    {
+        var latest = Volatile.Read(ref this.publishedSequence);
+        if (latest < 0)
+        {
+            return 0;
+        }
+
+        return (int)Math.Min(this.buffer.Length, Math.Max(0, latest - lastSequence));
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,3 @@
-
 using CefSharp;
 using CefSharp.OffScreen;
 using Microsoft.AspNetCore.Builder;
@@ -12,6 +11,7 @@ using Serilog;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Tractus.HtmlToNdi.Chromium;
+using Tractus.HtmlToNdi.FramePacing;
 using Tractus.HtmlToNdi.Models;
 
 namespace Tractus.HtmlToNdi;
@@ -19,6 +19,8 @@ public class Program
 {
     public static nint NdiSenderPtr;
     public static CefWrapper browserWrapper;
+    public static FrameRingBuffer<BrowserFrame>? VideoFrameBuffer;
+    public static FramePacer? VideoFramePacer;
 
     public static void Main(string[] args)
     {
@@ -122,6 +124,49 @@ public class Program
             }
         }
 
+        var bufferDepth = 5;
+        if (args.Any(x => x.StartsWith("--buffer-depth")))
+        {
+            try
+            {
+                bufferDepth = int.Parse(args.FirstOrDefault(x => x.StartsWith("--buffer-depth")).Split("=")[1]);
+
+                if (bufferDepth <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(bufferDepth));
+                }
+            }
+            catch (Exception)
+            {
+                Log.Error("Could not parse the --buffer-depth parameter. Exiting.");
+                return;
+            }
+        }
+
+        var frameRate = FrameRate.Default2997;
+        if (args.Any(x => x.StartsWith("--fps")))
+        {
+            try
+            {
+                var fpsValue = args.FirstOrDefault(x => x.StartsWith("--fps")).Split("=")[1];
+                if (!FrameRate.TryParse(fpsValue, out frameRate))
+                {
+                    throw new ArgumentException();
+                }
+            }
+            catch (Exception)
+            {
+                Log.Error("Could not parse the --fps parameter. Exiting.");
+                return;
+            }
+        }
+
+        var disableVsync = args.Any(x => string.Equals(x, "--disable-vsync", StringComparison.OrdinalIgnoreCase));
+        var disableFrameRateLimit = args.Any(x => string.Equals(x, "--disable-frame-rate-limit", StringComparison.OrdinalIgnoreCase));
+
+        var frameBuffer = new FrameRingBuffer<BrowserFrame>(bufferDepth);
+        VideoFrameBuffer = frameBuffer;
+
         AsyncContext.Run(async delegate
         {
             var settings = new CefSettings();
@@ -136,14 +181,23 @@ public class Program
             //settings.CefCommandLineArgs.Add("--in-process-gpu");
             //settings.SetOffScreenRenderingBestPerformanceArgs();
             settings.CefCommandLineArgs.Add("autoplay-policy", "no-user-gesture-required");
-            //settings.CefCommandLineArgs.Add("off-screen-frame-rate", "60");
-            //settings.CefCommandLineArgs.Add("disable-frame-rate-limit");
+            if (disableFrameRateLimit)
+            {
+                settings.CefCommandLineArgs.Add("disable-frame-rate-limit");
+            }
+
+            if (disableVsync)
+            {
+                settings.CefCommandLineArgs.Add("disable-gpu-vsync");
+            }
+
             settings.EnableAudio();
             Cef.Initialize(settings);
             browserWrapper = new CefWrapper(
                 width,
                 height,
-                startUrl);
+                startUrl,
+                frameBuffer);
 
             await browserWrapper.InitializeWrapperAsync();
         });
@@ -171,6 +225,48 @@ public class Program
         };
 
         Program.NdiSenderPtr = NDIlib.send_create(ref settings_T);
+
+        var pacerLogger = Log.ForContext<FramePacer>();
+        var framePacer = new FramePacer(
+            frameBuffer,
+            frameRate,
+            (frame, context) =>
+            {
+                if (Program.NdiSenderPtr == nint.Zero)
+                {
+                    return;
+                }
+
+                if (!frame.HasBuffer)
+                {
+                    return;
+                }
+
+                unsafe
+                {
+                    fixed (byte* bufferPtr = frame.PixelBuffer)
+                    {
+                        var videoFrame = new NDIlib.video_frame_v2_t()
+                        {
+                            FourCC = NDIlib.FourCC_type_e.FourCC_type_BGRA,
+                            frame_rate_N = frameRate.Numerator,
+                            frame_rate_D = frameRate.Denominator,
+                            frame_format_type = NDIlib.frame_format_type_e.frame_format_type_progressive,
+                            line_stride_in_bytes = frame.Stride,
+                            picture_aspect_ratio = frame.AspectRatio,
+                            p_data = (nint)bufferPtr,
+                            timecode = NDIlib.send_timecode_synthesize,
+                            xres = frame.Width,
+                            yres = frame.Height,
+                        };
+
+                        NDIlib.send_send_video_v2(Program.NdiSenderPtr, ref videoFrame);
+                    }
+                }
+            },
+            pacerLogger);
+        framePacer.Start();
+        VideoFramePacer = framePacer;
 
         var capabilitiesXml = $$"""<ndi_capabilities ntk_kvm="true" />""";
         capabilitiesXml += "\0";
@@ -202,7 +298,7 @@ public class Program
                 {
                     var metadataConverted = UTF.Utf8ToString(metadata.p_data);
 
-                    if(metadataConverted.StartsWith("<ndi_kvm u=\""))
+                    if (metadataConverted.StartsWith("<ndi_kvm u=\""))
                     {
                         metadataConverted = metadataConverted.Replace("<ndi_kvm u=\"", "");
                         metadataConverted = metadataConverted.Replace("\"/>", "");
@@ -213,12 +309,12 @@ public class Program
 
                             var opcode = binary[0];
 
-                            if(opcode == 0x03)
+                            if (opcode == 0x03)
                             {
                                 x = BitConverter.ToSingle(binary, 1);
                                 y = BitConverter.ToSingle(binary, 5);
                             }
-                            else if(opcode == 0x04)
+                            else if (opcode == 0x04)
                             {
                                 // Mouse Left Down
                                 var screenX = (int)(x * width);
@@ -226,7 +322,7 @@ public class Program
 
                                 browserWrapper.Click(screenX, screenY);
                             }
-                            else if(opcode == 0x07)
+                            else if (opcode == 0x07)
                             {
                                 // Mouse Left Up
                             }
@@ -285,6 +381,24 @@ public class Program
 
         running = false;
         thread.Join();
+
+        var pacerMetrics = VideoFramePacer?.GetMetricsSnapshot();
+        VideoFramePacer?.Dispose();
+
+        if (pacerMetrics.HasValue)
+        {
+            var metrics = pacerMetrics.Value;
+            var avgIntervalText = metrics.AverageIntervalMilliseconds?.ToString("F3") ?? "n/a";
+            var avgLatencyText = metrics.AverageLatencyMilliseconds?.ToString("F3") ?? "n/a";
+            Log.Information(
+                "Frame pacing summary: sent {Sent} frames, repeats {Repeats}, drops {Drops}, avg interval {AverageInterval} ms, avg latency {AverageLatency} ms",
+                metrics.FramesSent,
+                metrics.RepeatedFrames,
+                metrics.DroppedFrames,
+                avgIntervalText,
+                avgLatencyText);
+        }
+
         browserWrapper.Dispose();
 
         if (Directory.Exists(launchCachePath))

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Tractus.HtmlToNdi.Tests")]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tractus HTML to NDI Utility
 
-A simple wrapper around [CEFSharp](https://github.com/cefsharp/CefSharp) and [NDI Wrapper for .NET](https://github.com/eliaspuurunen/NdiLibDotNetCoreBase). Sends HTML pages to NDI, including audio if playback on the page is supported.
+A simple wrapper around [CEFSharp](https://github.com/cefsharp/CefSharp) and [NDI Wrapper for .NET](https://github.com/eliaspuuruunen/NdiLibDotNetCoreBase). Sends HTML pages to NDI, including audio if playback on the page is supported.
 
 [Grab the latest ZIP file](https://github.com/tractusevents/Tractus.HtmlToNdi/releases) from the releases page.
 
@@ -15,10 +15,14 @@ If the web page you are loading has a transparent background, NDI will honor tha
 Parameter|Description
 ----|---
 `--ndiname="NDI Source Name"`|The source name this browser instance will send. Defaults to "`HTML5`".
-`--width=1920`|The width of the browser source. Defaults to `1920`.
-`--width=1080`|The height of the browser source. Defaults to `1080`.
+`--w=1920`|The width of the browser source. Defaults to `1920`.
+`--h=1080`|The height of the browser source. Defaults to `1080`.
 `--port=9999`|The port the HTTP server will listen on. Defaults to `9999`.
 `--url="https://www.tractus.ca"`|The startup webpage. Defaults to `https://testpattern.tractusevents.com/`.
+`--fps=29.97`|Target NDI frame rate. Accepts floating point values (e.g., `29.97`) or ratios (e.g., `30000/1001`). Defaults to `29.97` fps.
+`--buffer-depth=5`|Number of frames stored in the pacing buffer before the newest frame overwrites the oldest. Defaults to `5`.
+`--disable-vsync`|Adds the Chromium `--disable-gpu-vsync` flag during startup.
+`--disable-frame-rate-limit`|Adds the Chromium `--disable-frame-rate-limit` flag during startup.
 
 #### Example Launch
 
@@ -35,7 +39,7 @@ Route|Method|Description|Example
 - Frames are sent to NDI in RGBA format. Some machines may experience a slight performance penalty.
 - H.264 and any other non-free codecs are not available for video playback since this uses Chromium. Sites like YouTube likely won't work.
 - Audio data received from the browser is passed to NDI directly.
-- NDI frame rate is set to 60 frames per second. The internal max render frame rate is set to be capped at 60 frames per second.
+- Video is paced to 29.97 fps by default but both the NDI output rate and Chromium's internal frame rate cap are configurable via command-line switches.
 
 ## More Tools
 

--- a/Tractus.HtmlToNdi.Tests/FramePacing/FramePacerEngineTests.cs
+++ b/Tractus.HtmlToNdi.Tests/FramePacing/FramePacerEngineTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Tractus.HtmlToNdi.FramePacing;
+using Xunit;
+
+namespace Tractus.HtmlToNdi.Tests.FramePacing;
+
+public class FramePacerEngineTests
+{
+    [Fact]
+    public void RingBufferReturnsLatestAndReportsDrops()
+    {
+        var buffer = new FrameRingBuffer<BrowserFrame>(3);
+        long sequence = -1;
+
+        for (var i = 0; i < 5; i++)
+        {
+            buffer.Push(CreateFrame(i + 1, 32, 18, DateTime.UtcNow.AddMilliseconds(i)));
+        }
+
+        Assert.Equal(3, buffer.GetBacklog(sequence));
+
+        var hasFrame = buffer.TryGetLatest(ref sequence, out var latest, out var dropped);
+
+        Assert.True(hasFrame);
+        Assert.Equal(4, dropped);
+        Assert.Equal(5, latest.PixelBuffer[0]);
+        Assert.Equal(0, buffer.GetBacklog(sequence));
+    }
+
+    [Fact]
+    public void EngineRepeatsAndDropsAsExpected()
+    {
+        var buffer = new FrameRingBuffer<BrowserFrame>(3);
+        var logger = new LoggerConfiguration().MinimumLevel.Debug().WriteTo.Sink(new NullSink()).CreateLogger();
+        var sent = new List<(BrowserFrame frame, FrameDeliveryContext context, DateTime tick)>();
+        var currentTick = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var engine = new FramePacerEngine(buffer, FrameRate.Default2997, (frame, context) =>
+        {
+            sent.Add((frame, context, currentTick));
+        },
+        logger);
+
+        var interval = engine.Interval;
+
+        var firstFrame = CreateFrame(1, 64, 36, currentTick);
+        buffer.Push(firstFrame);
+
+        engine.ProcessTick(currentTick);
+        Assert.Single(sent);
+        Assert.False(sent[0].context.IsRepeat);
+        Assert.Equal(0, sent[0].context.DroppedFrames);
+
+        currentTick = currentTick.Add(interval);
+        engine.ProcessTick(currentTick);
+        Assert.Equal(2, sent.Count);
+        Assert.True(sent[1].context.IsRepeat);
+
+        var secondFrameCapture = currentTick.AddMilliseconds(-5);
+        var secondFrame = CreateFrame(2, 64, 36, secondFrameCapture);
+        buffer.Push(secondFrame);
+
+        currentTick = currentTick.Add(interval);
+        engine.ProcessTick(currentTick);
+        Assert.Equal(3, sent.Count);
+        Assert.False(sent[2].context.IsRepeat);
+        Assert.Equal(0, sent[2].context.DroppedFrames);
+
+        buffer.Push(CreateFrame(3, 64, 36, currentTick.AddMilliseconds(-2)));
+        buffer.Push(CreateFrame(4, 64, 36, currentTick.AddMilliseconds(-1)));
+
+        currentTick = currentTick.Add(interval);
+        engine.ProcessTick(currentTick);
+
+        Assert.Equal(4, sent.Count);
+        Assert.False(sent[3].context.IsRepeat);
+        Assert.True(sent[3].context.DroppedFrames >= 1);
+    }
+
+    private static BrowserFrame CreateFrame(int id, int width, int height, DateTime capturedAt)
+    {
+        var stride = width * 4;
+        var buffer = new byte[stride * height];
+        buffer[0] = (byte)id;
+        return new BrowserFrame(buffer, width, height, stride, (float)width / height, capturedAt);
+    }
+
+    private sealed class NullSink : ILogEventSink
+    {
+        public void Emit(LogEvent logEvent)
+        {
+        }
+    }
+}

--- a/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
+++ b/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Serilog" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Tractus.HtmlToNdi.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tractus.HtmlToNdi.sln
+++ b/Tractus.HtmlToNdi.sln
@@ -5,27 +5,37 @@ VisualStudioVersion = 17.11.35303.130
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tractus.HtmlToNdi", "Tractus.HtmlToNdi.csproj", "{6B6C038D-3984-455A-95CA-A9079B3FC4E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tractus.HtmlToNdi.Tests", "Tractus.HtmlToNdi.Tests\Tractus.HtmlToNdi.Tests.csproj", "{BDABB725-B1D3-4A1D-AFEA-EF653D921C24}"
+EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|x64.ActiveCfg = Debug|x64
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|x64.Build.0 = Debug|x64
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.ActiveCfg = Release|x64
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.Build.0 = Release|x64
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {98900FA9-6DCC-44CD-9444-B6E359863CCB}
-	EndGlobalSection
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Debug|x64 = Debug|x64
+Release|Any CPU = Release|Any CPU
+Release|x64 = Release|x64
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|x64.ActiveCfg = Debug|x64
+{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|x64.Build.0 = Debug|x64
+{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.Build.0 = Release|Any CPU
+{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.ActiveCfg = Release|x64
+{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.Build.0 = Release|x64
+{BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Debug|x64.ActiveCfg = Debug|Any CPU
+{BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Debug|x64.Build.0 = Debug|Any CPU
+{BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Release|Any CPU.Build.0 = Release|Any CPU
+{BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Release|x64.ActiveCfg = Release|Any CPU
+{BDABB725-B1D3-4A1D-AFEA-EF653D921C24}.Release|x64.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+GlobalSection(ExtensibilityGlobals) = postSolution
+SolutionGuid = {98900FA9-6DCC-44CD-9444-B6E359863CCB}
+EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add a dedicated FramePacing module with ring buffer, pacing engine, and metrics to decouple Chromium paint callbacks from NDI sends
- update Program to configure the buffer/pacer via new CLI options, spin the pacing thread, and log frame cadence while CefWrapper now copies paint buffers into the ring buffer
- refresh AGENTS.md/README.md and add xUnit coverage for the pacing engine and buffer semantics

## Testing
- `dotnet build` *(fails: `dotnet` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da3e938c00832997ab856c513e080b