### PR TITLE
Implement paced frame buffer with configurable frame rate

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -294,7 +294,7 @@ public class Program
             }
         });
 
-        var capabilitiesXml = $$"""<ndi_capabilities ntk_kvm=\"true\" />""";
+        var capabilitiesXml = $$"""<ndi_capabilities ntk_kvm="true" />""";
         capabilitiesXml += "\0";
         var capabilitiesPtr = UTF.StringToUtf8(capabilitiesXml);
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,3 @@
-
 using CefSharp;
 using CefSharp.OffScreen;
 using Microsoft.AspNetCore.Builder;
@@ -9,16 +8,19 @@ using Microsoft.Extensions.Hosting;
 using NewTek;
 using NewTek.NDI;
 using Serilog;
-using System.Runtime.CompilerServices;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using Tractus.HtmlToNdi.Chromium;
 using Tractus.HtmlToNdi.Models;
+using Tractus.HtmlToNdi.Video;
 
 namespace Tractus.HtmlToNdi;
 public class Program
 {
     public static nint NdiSenderPtr;
     public static CefWrapper browserWrapper;
+
+    private static FramePacer? framePacer;
 
     public static void Main(string[] args)
     {
@@ -61,7 +63,7 @@ public class Program
         {
             try
             {
-                port = int.Parse(args.FirstOrDefault(x => x.StartsWith("--port")).Split("=")[1]);
+                port = int.Parse(args.FirstOrDefault(x => x.StartsWith("--port")).Split("=")[1], CultureInfo.InvariantCulture);
             }
             catch (Exception)
             {
@@ -100,7 +102,7 @@ public class Program
         {
             try
             {
-                width = int.Parse(args.FirstOrDefault(x => x.StartsWith("--w")).Split("=")[1]);
+                width = int.Parse(args.FirstOrDefault(x => x.StartsWith("--w")).Split("=")[1], CultureInfo.InvariantCulture);
             }
             catch (Exception)
             {
@@ -113,7 +115,7 @@ public class Program
         {
             try
             {
-                height = int.Parse(args.FirstOrDefault(x => x.StartsWith("--h")).Split("=")[1]);
+                height = int.Parse(args.FirstOrDefault(x => x.StartsWith("--h")).Split("=")[1], CultureInfo.InvariantCulture);
             }
             catch (Exception)
             {
@@ -121,6 +123,80 @@ public class Program
                 return;
             }
         }
+
+        var bufferDepth = 5;
+        if (args.Any(x => x.StartsWith("--buffer-depth", StringComparison.OrdinalIgnoreCase)))
+        {
+            try
+            {
+                var value = args.First(x => x.StartsWith("--buffer-depth", StringComparison.OrdinalIgnoreCase)).Split("=")[1];
+                bufferDepth = int.Parse(value, CultureInfo.InvariantCulture);
+                if (bufferDepth <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(bufferDepth));
+                }
+            }
+            catch (Exception)
+            {
+                Log.Error("Could not parse the --buffer-depth parameter. Exiting.");
+                return;
+            }
+        }
+
+        var targetFrameRate = FrameRate.Ntsc2997;
+        if (args.Any(x => x.StartsWith("--fps", StringComparison.OrdinalIgnoreCase)))
+        {
+            var value = args.First(x => x.StartsWith("--fps", StringComparison.OrdinalIgnoreCase)).Split("=")[1];
+            if (!FrameRate.TryParse(value, out targetFrameRate))
+            {
+                Log.Error("Could not parse the --fps parameter. Expected a decimal (e.g. 29.97) or ratio (e.g. 30000/1001). Exiting.");
+                return;
+            }
+        }
+
+        int? windowlessFrameRateOverride = null;
+        if (args.Any(x => x.StartsWith("--windowless-frame-rate", StringComparison.OrdinalIgnoreCase)))
+        {
+            try
+            {
+                var value = args.First(x => x.StartsWith("--windowless-frame-rate", StringComparison.OrdinalIgnoreCase)).Split("=")[1];
+                var parsed = int.Parse(value, CultureInfo.InvariantCulture);
+                if (parsed <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(parsed));
+                }
+
+                windowlessFrameRateOverride = parsed;
+            }
+            catch (Exception)
+            {
+                Log.Error("Could not parse the --windowless-frame-rate parameter. Exiting.");
+                return;
+            }
+        }
+
+        var disableGpuVsync = args.Any(x => string.Equals(x, "--disable-gpu-vsync", StringComparison.OrdinalIgnoreCase));
+        var disableFrameRateLimit = args.Any(x => string.Equals(x, "--disable-frame-rate-limit", StringComparison.OrdinalIgnoreCase));
+
+        var chromiumFrameRate = windowlessFrameRateOverride ?? Math.Max(60, (int)Math.Ceiling(targetFrameRate.FramesPerSecond * 2));
+
+        Log.Information(
+            "Frame pacing configured for {Fps:F3} fps with buffer depth {Depth} and Chromium windowless frame rate {ChromiumFps} fps.",
+            targetFrameRate.FramesPerSecond,
+            bufferDepth,
+            chromiumFrameRate);
+
+        if (disableGpuVsync)
+        {
+            Log.Information("Chromium GPU VSync disabled via --disable-gpu-vsync.");
+        }
+
+        if (disableFrameRateLimit)
+        {
+            Log.Information("Chromium frame rate limiter disabled via --disable-frame-rate-limit.");
+        }
+
+        var frameBuffer = new FrameRingBuffer(bufferDepth);
 
         AsyncContext.Run(async delegate
         {
@@ -136,14 +212,24 @@ public class Program
             //settings.CefCommandLineArgs.Add("--in-process-gpu");
             //settings.SetOffScreenRenderingBestPerformanceArgs();
             settings.CefCommandLineArgs.Add("autoplay-policy", "no-user-gesture-required");
-            //settings.CefCommandLineArgs.Add("off-screen-frame-rate", "60");
-            //settings.CefCommandLineArgs.Add("disable-frame-rate-limit");
+            if (disableGpuVsync)
+            {
+                settings.CefCommandLineArgs.Add("disable-gpu-vsync");
+            }
+
+            if (disableFrameRateLimit)
+            {
+                settings.CefCommandLineArgs.Add("disable-frame-rate-limit");
+            }
+
             settings.EnableAudio();
             Cef.Initialize(settings);
             browserWrapper = new CefWrapper(
                 width,
                 height,
-                startUrl);
+                startUrl,
+                frameBuffer,
+                chromiumFrameRate);
 
             await browserWrapper.InitializeWrapperAsync();
         });
@@ -172,7 +258,43 @@ public class Program
 
         Program.NdiSenderPtr = NDIlib.send_create(ref settings_T);
 
-        var capabilitiesXml = $$"""<ndi_capabilities ntk_kvm="true" />""";
+        framePacer = new FramePacer(frameBuffer, targetFrameRate, output =>
+        {
+            if (Program.NdiSenderPtr == nint.Zero)
+            {
+                return;
+            }
+
+            if (output.Metadata.Width == 0 || output.Metadata.Height == 0 || output.Metadata.BufferLength == 0)
+            {
+                return;
+            }
+
+            unsafe
+            {
+                var span = output.PixelData.Span;
+                fixed (byte* dataPtr = span)
+                {
+                    var videoFrame = new NDIlib.video_frame_v2_t()
+                    {
+                        FourCC = NDIlib.FourCC_type_e.FourCC_type_BGRA,
+                        frame_rate_N = targetFrameRate.Numerator,
+                        frame_rate_D = targetFrameRate.Denominator,
+                        frame_format_type = NDIlib.frame_format_type_e.frame_format_type_progressive,
+                        line_stride_in_bytes = output.Metadata.Stride,
+                        picture_aspect_ratio = (float)output.Metadata.Width / output.Metadata.Height,
+                        p_data = (nint)dataPtr,
+                        timecode = NDIlib.send_timecode_synthesize,
+                        xres = output.Metadata.Width,
+                        yres = output.Metadata.Height,
+                    };
+
+                    NDIlib.send_send_video_v2(Program.NdiSenderPtr, ref videoFrame);
+                }
+            }
+        });
+
+        var capabilitiesXml = $$"""<ndi_capabilities ntk_kvm=\"true\" />""";
         capabilitiesXml += "\0";
         var capabilitiesPtr = UTF.StringToUtf8(capabilitiesXml);
 
@@ -285,6 +407,7 @@ public class Program
 
         running = false;
         thread.Join();
+        framePacer?.Dispose();
         browserWrapper.Dispose();
 
         if (Directory.Exists(launchCachePath))

--- a/README.md
+++ b/README.md
@@ -14,15 +14,20 @@ If the web page you are loading has a transparent background, NDI will honor tha
 
 Parameter|Description
 ----|---
-`--ndiname="NDI Source Name"`|The source name this browser instance will send. Defaults to "`HTML5`".
-`--width=1920`|The width of the browser source. Defaults to `1920`.
-`--width=1080`|The height of the browser source. Defaults to `1080`.
+`--ndiname="NDI Source Name"`|The source name this browser instance will send. Defaults to `HTML5` and will prompt if omitted.
 `--port=9999`|The port the HTTP server will listen on. Defaults to `9999`.
 `--url="https://www.tractus.ca"`|The startup webpage. Defaults to `https://testpattern.tractusevents.com/`.
+`--w=1920`|The width of the browser source in pixels. Defaults to `1920`.
+`--h=1080`|The height of the browser source in pixels. Defaults to `1080`.
+`--fps=29.97`|Target NDI frame rate. Supports decimal values (e.g. `29.97`) or ratios (e.g. `30000/1001`). Defaults to 29.97 fps.
+`--buffer-depth=5`|Number of frames retained in the pacing ring buffer before overwriting. Higher values add latency but improve burst tolerance. Defaults to `5`.
+`--windowless-frame-rate=120`|Override Chromium's internal windowless frame rate. By default the app chooses the greater of 60 fps or double the requested NDI rate.
+`--disable-gpu-vsync`|Forwarded to Chromium to disable GPU VSync. Useful on machines where Chromium's compositor throttles rendering.
+`--disable-frame-rate-limit`|Forwarded to Chromium to disable the renderer's internal frame-rate limiter.
 
 #### Example Launch
 
-`.\Tractus.HtmlToNdi.exe --ndiname="HTML 5 Test" --w=1080 --h=1080 --url="https://testpattern.tractusevents.com"`
+`.\Tractus.HtmlToNdi.exe --ndiname="HTML 5 Test" --w=1080 --h=1080 --url="https://testpattern.tractusevents.com" --fps=59.94 --buffer-depth=6`
 
 ## API Routes
 
@@ -32,10 +37,10 @@ Route|Method|Description|Example
 
 ## Known Limitations
 
-- Frames are sent to NDI in RGBA format. Some machines may experience a slight performance penalty.
+- Frames are sent to NDI in BGRA format. Some machines may experience a slight performance penalty.
 - H.264 and any other non-free codecs are not available for video playback since this uses Chromium. Sites like YouTube likely won't work.
 - Audio data received from the browser is passed to NDI directly.
-- NDI frame rate is set to 60 frames per second. The internal max render frame rate is set to be capped at 60 frames per second.
+- Chromium still renders off-screen at the configured windowless rate; choose values carefully to avoid unnecessary CPU usage.
 
 ## More Tools
 

--- a/Video/FrameMetadata.cs
+++ b/Video/FrameMetadata.cs
@@ -1,0 +1,19 @@
+namespace Tractus.HtmlToNdi.Video;
+
+public readonly struct FrameMetadata
+{
+    public FrameMetadata(int width, int height, int stride, int bufferLength, DateTime capturedAtUtc)
+    {
+        this.Width = width;
+        this.Height = height;
+        this.Stride = stride;
+        this.BufferLength = bufferLength;
+        this.CapturedAtUtc = capturedAtUtc;
+    }
+
+    public int Width { get; }
+    public int Height { get; }
+    public int Stride { get; }
+    public int BufferLength { get; }
+    public DateTime CapturedAtUtc { get; }
+}

--- a/Video/FrameOutput.cs
+++ b/Video/FrameOutput.cs
@@ -1,0 +1,19 @@
+namespace Tractus.HtmlToNdi.Video;
+
+public readonly struct FrameOutput
+{
+    public FrameOutput(FrameMetadata metadata, ReadOnlyMemory<byte> pixelData, bool isRepeat, int droppedFrames, TimeSpan actualInterval)
+    {
+        this.Metadata = metadata;
+        this.PixelData = pixelData;
+        this.IsRepeat = isRepeat;
+        this.DroppedFrames = droppedFrames;
+        this.ActualInterval = actualInterval;
+    }
+
+    public FrameMetadata Metadata { get; }
+    public ReadOnlyMemory<byte> PixelData { get; }
+    public bool IsRepeat { get; }
+    public int DroppedFrames { get; }
+    public TimeSpan ActualInterval { get; }
+}

--- a/Video/FramePacer.cs
+++ b/Video/FramePacer.cs
@@ -1,0 +1,311 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading;
+using Serilog;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public sealed class FramePacer : IDisposable
+{
+    private readonly FrameRingBuffer buffer;
+    private readonly FrameRate targetFrameRate;
+    private readonly Action<FrameOutput> frameConsumer;
+    private readonly FramePacerOptions options;
+    private readonly object stateLock = new();
+    private readonly object metricsLock = new();
+
+    private Thread? workerThread;
+    private volatile bool running;
+    private bool disposed;
+    private byte[] currentFrame = Array.Empty<byte>();
+    private FrameMetadata currentMetadata;
+    private bool hasCurrentFrame;
+    private DateTime lastTickUtc = DateTime.MinValue;
+    private DateTime lastLogUtc = DateTime.MinValue;
+    private readonly Stopwatch stopwatch = new();
+
+    private long sentFrames;
+    private long repeatedFrames;
+    private long droppedFrames;
+    private double minIntervalMs = double.MaxValue;
+    private double maxIntervalMs = 0;
+    private double accumulatedIntervalMs;
+
+    private long totalSentFrames;
+    private long totalRepeatedFrames;
+    private long totalDroppedFrames;
+    private double totalIntervalMs;
+    private double totalMinIntervalMs = double.MaxValue;
+    private double totalMaxIntervalMs;
+    private long totalIntervalCount;
+
+    public FramePacer(FrameRingBuffer buffer, FrameRate targetFrameRate, Action<FrameOutput> frameConsumer, FramePacerOptions? options = null)
+    {
+        this.buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+        this.targetFrameRate = targetFrameRate;
+        this.frameConsumer = frameConsumer ?? throw new ArgumentNullException(nameof(frameConsumer));
+        this.options = options ?? new FramePacerOptions();
+
+        if (this.options.StartImmediately)
+        {
+            this.Start();
+        }
+    }
+
+    public TimeSpan TargetInterval => this.targetFrameRate.FrameInterval;
+
+    public void Start()
+    {
+        lock (this.stateLock)
+        {
+            if (this.running)
+            {
+                return;
+            }
+
+            this.running = true;
+            this.workerThread = new Thread(this.Run)
+            {
+                Name = "FramePacer",
+                IsBackground = true,
+                Priority = ThreadPriority.AboveNormal,
+            };
+
+            this.workerThread.Start();
+        }
+    }
+
+    public void Stop()
+    {
+        lock (this.stateLock)
+        {
+            this.running = false;
+        }
+
+        if (this.workerThread is not null && Thread.CurrentThread != this.workerThread)
+        {
+            this.workerThread.Join();
+            this.workerThread = null;
+        }
+    }
+
+    public FramePacerMetrics GetMetricsSnapshot()
+    {
+        lock (this.metricsLock)
+        {
+            double? avgInterval = this.totalIntervalCount > 0
+                ? this.totalIntervalMs / this.totalIntervalCount
+                : null;
+
+            double? minInterval = this.totalIntervalCount > 0 && this.totalMinIntervalMs != double.MaxValue
+                ? this.totalMinIntervalMs
+                : null;
+
+            double? maxInterval = this.totalIntervalCount > 0 && this.totalMaxIntervalMs != 0
+                ? this.totalMaxIntervalMs
+                : null;
+
+            return new FramePacerMetrics(
+                this.totalSentFrames,
+                this.totalRepeatedFrames,
+                this.totalDroppedFrames,
+                avgInterval,
+                minInterval,
+                maxInterval,
+                this.TargetInterval.TotalMilliseconds);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (this.disposed)
+        {
+            return;
+        }
+
+        this.Stop();
+
+        var summary = this.GetMetricsSnapshot();
+        if (summary.FramesSent > 0)
+        {
+            Log.Information(
+                "Frame pacing summary: sent={Sent} repeats={Repeats} drops={Dropped} avg_interval={Average}ms min_interval={Min}ms max_interval={Max}ms target_interval={Target}ms",
+                summary.FramesSent,
+                summary.RepeatedFrames,
+                summary.DroppedFrames,
+                FormatInterval(summary.AverageIntervalMilliseconds),
+                FormatInterval(summary.MinIntervalMilliseconds),
+                FormatInterval(summary.MaxIntervalMilliseconds),
+                summary.TargetIntervalMilliseconds.ToString("F3", CultureInfo.InvariantCulture));
+        }
+
+        this.disposed = true;
+    }
+
+    internal void RunTick(DateTime utcNow)
+    {
+        var actualInterval = this.lastTickUtc == DateTime.MinValue
+            ? this.TargetInterval
+            : utcNow - this.lastTickUtc;
+        this.lastTickUtc = utcNow;
+
+        var hasNewFrame = this.TryReadLatestFrame(out var metadata, out var dropped);
+        var droppedForFrame = 0;
+
+        if (hasNewFrame)
+        {
+            this.currentMetadata = metadata;
+            this.hasCurrentFrame = true;
+            this.droppedFrames += dropped;
+            droppedForFrame = dropped;
+        }
+        else if (!this.hasCurrentFrame)
+        {
+            return;
+        }
+        else
+        {
+            this.repeatedFrames++;
+        }
+
+        var isRepeat = !hasNewFrame;
+        var output = new FrameOutput(this.currentMetadata, new ReadOnlyMemory<byte>(this.currentFrame, 0, this.currentMetadata.BufferLength), isRepeat, droppedForFrame, actualInterval);
+        this.frameConsumer(output);
+        this.sentFrames++;
+
+        this.TrackInterval(actualInterval, isRepeat, droppedForFrame);
+        this.LogMetricsIfNeeded(utcNow);
+    }
+
+    private void Run()
+    {
+        this.stopwatch.Restart();
+        var nextDeadline = this.stopwatch.Elapsed;
+
+        while (this.running)
+        {
+            nextDeadline += this.TargetInterval;
+            this.SleepUntil(nextDeadline);
+            this.RunTick(DateTime.UtcNow);
+        }
+    }
+
+    private bool TryReadLatestFrame(out FrameMetadata metadata, out int dropped)
+    {
+        metadata = default;
+        dropped = 0;
+
+        while (true)
+        {
+            try
+            {
+                var hasNew = this.buffer.TryCopyLatest(this.currentFrame.AsSpan(), out metadata, out dropped);
+                if (!hasNew)
+                {
+                    return false;
+                }
+
+                if (metadata.BufferLength > this.currentFrame.Length)
+                {
+                    this.currentFrame = new byte[metadata.BufferLength];
+                    continue;
+                }
+
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                var snapshot = this.buffer.GetLatestSnapshot();
+                var required = snapshot.HasValue ? snapshot.Metadata.BufferLength : metadata.BufferLength;
+                if (required <= 0)
+                {
+                    return false;
+                }
+
+                this.currentFrame = new byte[required];
+            }
+        }
+    }
+
+    private void SleepUntil(TimeSpan target)
+    {
+        while (true)
+        {
+            var remaining = target - this.stopwatch.Elapsed;
+            if (remaining <= TimeSpan.Zero)
+            {
+                return;
+            }
+
+            if (remaining > TimeSpan.FromMilliseconds(2))
+            {
+                Thread.Sleep(remaining - TimeSpan.FromMilliseconds(1));
+            }
+            else
+            {
+                Thread.SpinWait(50);
+            }
+        }
+    }
+
+    private void TrackInterval(TimeSpan interval, bool isRepeat, int dropped)
+    {
+        var intervalMs = interval.TotalMilliseconds;
+        this.accumulatedIntervalMs += intervalMs;
+        this.minIntervalMs = Math.Min(this.minIntervalMs, intervalMs);
+        this.maxIntervalMs = Math.Max(this.maxIntervalMs, intervalMs);
+
+        lock (this.metricsLock)
+        {
+            this.totalSentFrames++;
+            if (isRepeat)
+            {
+                this.totalRepeatedFrames++;
+            }
+
+            this.totalDroppedFrames += dropped;
+            this.totalIntervalMs += intervalMs;
+            this.totalIntervalCount++;
+            this.totalMinIntervalMs = Math.Min(this.totalMinIntervalMs, intervalMs);
+            this.totalMaxIntervalMs = Math.Max(this.totalMaxIntervalMs, intervalMs);
+        }
+    }
+
+    private void LogMetricsIfNeeded(DateTime utcNow)
+    {
+        if (this.lastLogUtc != DateTime.MinValue && utcNow - this.lastLogUtc < this.options.MetricsLogInterval)
+        {
+            return;
+        }
+
+        var sent = this.sentFrames;
+        if (sent == 0)
+        {
+            return;
+        }
+
+        var avg = this.accumulatedIntervalMs / sent;
+        Log.Information("Frame pacer stats: sent={Sent} repeat={Repeated} dropped={Dropped} interval_avg={Avg:F3}ms interval_min={Min:F3}ms interval_max={Max:F3}ms target={Target:F3}ms buffer_depth={BufferDepth}",
+            sent,
+            this.repeatedFrames,
+            this.droppedFrames,
+            avg,
+            this.minIntervalMs,
+            this.maxIntervalMs,
+            this.TargetInterval.TotalMilliseconds,
+            this.buffer.Capacity);
+
+        this.lastLogUtc = utcNow;
+        this.accumulatedIntervalMs = 0;
+        this.minIntervalMs = double.MaxValue;
+        this.maxIntervalMs = 0;
+        this.sentFrames = 0;
+        this.repeatedFrames = 0;
+        this.droppedFrames = 0;
+    }
+
+    private static string FormatInterval(double? value)
+    {
+        return value.HasValue ? value.Value.ToString("F3", CultureInfo.InvariantCulture) : "n/a";
+    }
+}

--- a/Video/FramePacerMetrics.cs
+++ b/Video/FramePacerMetrics.cs
@@ -1,0 +1,30 @@
+namespace Tractus.HtmlToNdi.Video;
+
+public readonly struct FramePacerMetrics
+{
+    public FramePacerMetrics(
+        long framesSent,
+        long repeatedFrames,
+        long droppedFrames,
+        double? averageIntervalMilliseconds,
+        double? minIntervalMilliseconds,
+        double? maxIntervalMilliseconds,
+        double targetIntervalMilliseconds)
+    {
+        this.FramesSent = framesSent;
+        this.RepeatedFrames = repeatedFrames;
+        this.DroppedFrames = droppedFrames;
+        this.AverageIntervalMilliseconds = averageIntervalMilliseconds;
+        this.MinIntervalMilliseconds = minIntervalMilliseconds;
+        this.MaxIntervalMilliseconds = maxIntervalMilliseconds;
+        this.TargetIntervalMilliseconds = targetIntervalMilliseconds;
+    }
+
+    public long FramesSent { get; }
+    public long RepeatedFrames { get; }
+    public long DroppedFrames { get; }
+    public double? AverageIntervalMilliseconds { get; }
+    public double? MinIntervalMilliseconds { get; }
+    public double? MaxIntervalMilliseconds { get; }
+    public double TargetIntervalMilliseconds { get; }
+}

--- a/Video/FramePacerOptions.cs
+++ b/Video/FramePacerOptions.cs
@@ -1,0 +1,7 @@
+namespace Tractus.HtmlToNdi.Video;
+
+public sealed class FramePacerOptions
+{
+    public bool StartImmediately { get; set; } = true;
+    public TimeSpan MetricsLogInterval { get; set; } = TimeSpan.FromSeconds(1);
+}

--- a/Video/FrameRate.cs
+++ b/Video/FrameRate.cs
@@ -1,0 +1,107 @@
+using System.Globalization;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public readonly struct FrameRate
+{
+    public int Numerator { get; }
+    public int Denominator { get; }
+
+    public double FramesPerSecond => (double)this.Numerator / this.Denominator;
+    public TimeSpan FrameInterval => TimeSpan.FromSeconds((double)this.Denominator / this.Numerator);
+
+    private FrameRate(int numerator, int denominator)
+    {
+        if (numerator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(numerator));
+        }
+
+        if (denominator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(denominator));
+        }
+
+        this.Numerator = numerator;
+        this.Denominator = denominator;
+    }
+
+    public static FrameRate Create(int numerator, int denominator)
+    {
+        var gcd = GreatestCommonDivisor(Math.Abs(numerator), Math.Abs(denominator));
+        return new FrameRate(numerator / gcd, denominator / gcd);
+    }
+
+    public static FrameRate FromDouble(double framesPerSecond, int precision = 1000)
+    {
+        if (framesPerSecond <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(framesPerSecond));
+        }
+
+        var denominator = Math.Max(1, precision);
+        var numerator = (int)Math.Round(framesPerSecond * denominator, MidpointRounding.AwayFromZero);
+
+        if (numerator == 0)
+        {
+            numerator = 1;
+        }
+
+        return Create(numerator, denominator);
+    }
+
+    public static bool TryParse(string value, out FrameRate frameRate)
+    {
+        frameRate = default;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        value = value.Trim();
+        if (value.Contains('/'))
+        {
+            var parts = value.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length != 2)
+            {
+                return false;
+            }
+
+            if (int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var numerator) &&
+                int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var denominator))
+            {
+                frameRate = Create(numerator, denominator);
+                return true;
+            }
+
+            return false;
+        }
+
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var fps))
+        {
+            frameRate = FromDouble(fps);
+            return true;
+        }
+
+        return false;
+    }
+
+    public override string ToString()
+    {
+        return $"{this.Numerator}/{this.Denominator} ({this.FramesPerSecond:F3} fps)";
+    }
+
+    public static FrameRate Ntsc2997 { get; } = Create(30000, 1001);
+
+    private static int GreatestCommonDivisor(int a, int b)
+    {
+        while (b != 0)
+        {
+            var temp = b;
+            b = a % b;
+            a = temp;
+        }
+
+        return a == 0 ? 1 : a;
+    }
+}

--- a/Video/FrameRate.cs
+++ b/Video/FrameRate.cs
@@ -70,8 +70,20 @@ public readonly struct FrameRate
             if (int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var numerator) &&
                 int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var denominator))
             {
-                frameRate = Create(numerator, denominator);
-                return true;
+                if (numerator <= 0 || denominator <= 0)
+                {
+                    return false;
+                }
+
+                try
+                {
+                    frameRate = Create(numerator, denominator);
+                    return true;
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    return false;
+                }
             }
 
             return false;
@@ -79,8 +91,20 @@ public readonly struct FrameRate
 
         if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var fps))
         {
-            frameRate = FromDouble(fps);
-            return true;
+            if (fps <= 0)
+            {
+                return false;
+            }
+
+            try
+            {
+                frameRate = FromDouble(fps);
+                return true;
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return false;
+            }
         }
 
         return false;

--- a/Video/FrameRingBuffer.cs
+++ b/Video/FrameRingBuffer.cs
@@ -1,0 +1,122 @@
+using System.Threading;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public sealed class FrameRingBuffer
+{
+    private readonly FrameSlot[] slots;
+    private readonly int capacity;
+    private long writeSequence = -1;
+    private long publishedSequence = -1;
+    private long lastReadSequence = -1;
+
+    public FrameRingBuffer(int capacity)
+    {
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity));
+        }
+
+        this.capacity = capacity;
+        this.slots = new FrameSlot[capacity];
+        for (var i = 0; i < capacity; i++)
+        {
+            this.slots[i] = new FrameSlot();
+        }
+    }
+
+    public int Capacity => this.capacity;
+
+    public void WriteFrame(ReadOnlySpan<byte> pixels, int width, int height, int stride, DateTime capturedAtUtc)
+    {
+        var sequence = Interlocked.Increment(ref this.writeSequence);
+        var slot = this.slots[(int)(sequence % this.capacity)];
+        slot.Write(pixels, width, height, stride, capturedAtUtc);
+        Volatile.Write(ref this.publishedSequence, sequence);
+    }
+
+    public bool TryCopyLatest(Span<byte> destination, out FrameMetadata metadata, out int droppedFrames)
+    {
+        metadata = default;
+        droppedFrames = 0;
+
+        var published = Volatile.Read(ref this.publishedSequence);
+        if (published < 0)
+        {
+            return false;
+        }
+
+        var lastRead = Volatile.Read(ref this.lastReadSequence);
+        if (published == lastRead)
+        {
+            return false;
+        }
+
+        var slot = this.slots[(int)(published % this.capacity)];
+        slot.CopyTo(destination);
+        metadata = slot.Metadata;
+        droppedFrames = (int)Math.Max(0, published - lastRead - 1);
+        Volatile.Write(ref this.lastReadSequence, published);
+        return true;
+    }
+
+    public FrameBufferSnapshot GetLatestSnapshot()
+    {
+        var published = Volatile.Read(ref this.publishedSequence);
+        if (published < 0)
+        {
+            return FrameBufferSnapshot.Empty;
+        }
+
+        var slot = this.slots[(int)(published % this.capacity)];
+        return new FrameBufferSnapshot(slot.Metadata, slot.AsMemory());
+    }
+
+    private sealed class FrameSlot
+    {
+        private byte[] buffer = Array.Empty<byte>();
+        private FrameMetadata metadata;
+
+        public FrameMetadata Metadata => this.metadata;
+
+        public void Write(ReadOnlySpan<byte> pixels, int width, int height, int stride, DateTime capturedAtUtc)
+        {
+            var required = pixels.Length;
+            if (this.buffer.Length < required)
+            {
+                this.buffer = new byte[required];
+            }
+
+            pixels.CopyTo(this.buffer);
+            this.metadata = new FrameMetadata(width, height, stride, required, capturedAtUtc);
+        }
+
+        public void CopyTo(Span<byte> destination)
+        {
+            if (destination.Length < this.metadata.BufferLength)
+            {
+                throw new ArgumentException("Destination buffer too small", nameof(destination));
+            }
+
+            this.buffer.AsSpan(0, this.metadata.BufferLength).CopyTo(destination);
+        }
+
+        public ReadOnlyMemory<byte> AsMemory() => new ReadOnlyMemory<byte>(this.buffer, 0, this.metadata.BufferLength);
+    }
+}
+
+public readonly struct FrameBufferSnapshot
+{
+    public static readonly FrameBufferSnapshot Empty = new FrameBufferSnapshot(default, ReadOnlyMemory<byte>.Empty);
+
+    public FrameBufferSnapshot(FrameMetadata metadata, ReadOnlyMemory<byte> buffer)
+    {
+        this.Metadata = metadata;
+        this.Buffer = buffer;
+    }
+
+    public FrameMetadata Metadata { get; }
+    public ReadOnlyMemory<byte> Buffer { get; }
+
+    public bool HasValue => this.Buffer.Length > 0;
+}


### PR DESCRIPTION
## Summary
- add a reusable Video namespace with ring buffer and frame pacer to smooth Chromium paint cadence
- update CefWrapper and Program to write paints into the buffer, pace NDI output, and expose CLI toggles for fps, buffer depth, and Chromium frame-rate knobs
- refresh AGENTS.md and README.md to document the new frame pacing options and workflow

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da3e938c00832997ab856c513e080b