### PR TITLE
Implement frame pacing pipeline with configurable output

### DIFF
--- a/Chromium/CefWrapper.cs
+++ b/Chromium/CefWrapper.cs
@@ -1,12 +1,15 @@
 
 using CefSharp;
 using CefSharp.OffScreen;
-using NewTek;
+using Serilog;
+using Tractus.HtmlToNdi.Video;
 
 namespace Tractus.HtmlToNdi.Chromium;
 
 public class CefWrapper : IDisposable
 {
+    private readonly FrameRingBuffer frameBuffer;
+    private readonly int windowlessFrameRate;
     private bool disposedValue;
     private ChromiumWebBrowser? browser;
 
@@ -18,11 +21,13 @@ public class CefWrapper : IDisposable
     private Thread RenderWatchdog;
     private DateTime lastPaint = DateTime.MinValue;
 
-    public CefWrapper(int width, int height, string initialUrl)
+    public CefWrapper(int width, int height, string initialUrl, FrameRingBuffer frameBuffer, int windowlessFrameRate)
     {
         this.Width = width;
         this.Height = height;
         this.Url = initialUrl;
+        this.frameBuffer = frameBuffer ?? throw new ArgumentNullException(nameof(frameBuffer));
+        this.windowlessFrameRate = windowlessFrameRate;
 
         this.browser = new ChromiumWebBrowser(initialUrl)
         {
@@ -56,7 +61,7 @@ public class CefWrapper : IDisposable
 
         await this.browser.WaitForInitialLoadAsync();
 
-        this.browser.GetBrowserHost().WindowlessFrameRate = 60;
+        this.browser.GetBrowserHost().WindowlessFrameRate = this.windowlessFrameRate;
         this.browser.ToggleAudioMute();
 
         this.browser.Paint += this.OnBrowserPaint;
@@ -65,11 +70,6 @@ public class CefWrapper : IDisposable
 
     private void OnBrowserPaint(object? sender, OnPaintEventArgs e)
     {
-        if (Program.NdiSenderPtr == nint.Zero)
-        {
-            return;
-        }
-
         var browser = sender as ChromiumWebBrowser;
 
         if (browser is null)
@@ -77,23 +77,24 @@ public class CefWrapper : IDisposable
             return;
         }
 
+        if (e.Width == 0 || e.Height == 0)
+        {
+            return;
+        }
+
         this.lastPaint = DateTime.Now;
 
-        var videoFrame = new NDIlib.video_frame_v2_t()
+        try
         {
-            FourCC = NDIlib.FourCC_type_e.FourCC_type_BGRA,
-            frame_rate_N = 60,
-            frame_rate_D = 1,
-            frame_format_type = NDIlib.frame_format_type_e.frame_format_type_progressive,
-            line_stride_in_bytes = e.Width * 4,
-            picture_aspect_ratio = (float)e.Width / e.Height,
-            p_data = e.BufferHandle,
-            timecode = NDIlib.send_timecode_synthesize,
-            xres = e.Width,
-            yres = e.Height,
-        };
-
-        NDIlib.send_send_video_v2(Program.NdiSenderPtr, ref videoFrame);
+            var stride = e.Stride > 0 ? e.Stride : e.Width * 4;
+            var frame = VideoFrame.FromPointer(e.BufferHandle, e.Width, e.Height, stride, DateTime.UtcNow);
+            this.frameBuffer.Enqueue(frame);
+            frame.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to capture Chromium frame {Width}x{Height}", e.Width, e.Height);
+        }
     }
 
     protected virtual void Dispose(bool disposing)

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Tractus.HtmlToNdi.Tests")]

--- a/README.md
+++ b/README.md
@@ -14,11 +14,16 @@ If the web page you are loading has a transparent background, NDI will honor tha
 
 Parameter|Description
 ----|---
-`--ndiname="NDI Source Name"`|The source name this browser instance will send. Defaults to "`HTML5`".
-`--width=1920`|The width of the browser source. Defaults to `1920`.
-`--width=1080`|The height of the browser source. Defaults to `1080`.
+`--ndiname="NDI Source Name"`|The source name this browser instance will send. Defaults to `HTML5`.
+`--w=1920`|The width of the browser source. Defaults to `1920`.
+`--h=1080`|The height of the browser source. Defaults to `1080`.
 `--port=9999`|The port the HTTP server will listen on. Defaults to `9999`.
 `--url="https://www.tractus.ca"`|The startup webpage. Defaults to `https://testpattern.tractusevents.com/`.
+`--fps=29.97`|Target output frame rate. Accepts decimals (`29.97`) or ratios (`30000/1001`). Defaults to NTSC 29.97 fps.
+`--buffer-depth=5`|Number of frames to keep in the pacing buffer. Larger values smooth jitter at the cost of latency.
+`--windowless-frame-rate=60`|Overrides the internal Chromium render cadence. Defaults to twice the requested FPS, but never below 60.
+`--disable-gpu-vsync`|Disables Chromium's GPU vsync. Useful when pacing to non-60 fps outputs.
+`--disable-frame-rate-limit`|Lifts Chromium's renderer frame-rate limiter. Combine with vsync disabling for high-refresh experiments.
 
 #### Example Launch
 
@@ -32,10 +37,10 @@ Route|Method|Description|Example
 
 ## Known Limitations
 
-- Frames are sent to NDI in RGBA format. Some machines may experience a slight performance penalty.
+- Frames are sent to NDI in BGRA format. Some machines may experience a slight performance penalty.
 - H.264 and any other non-free codecs are not available for video playback since this uses Chromium. Sites like YouTube likely won't work.
 - Audio data received from the browser is passed to NDI directly.
-- NDI frame rate is set to 60 frames per second. The internal max render frame rate is set to be capped at 60 frames per second.
+- The frame pacer repeats the latest frame when Chromium stalls, but extremely long stalls (> buffer depth) still cause visible drops.
 
 ## More Tools
 

--- a/Tests/Tractus.HtmlToNdi.Tests/FramePacingTests.cs
+++ b/Tests/Tractus.HtmlToNdi.Tests/FramePacingTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Tractus.HtmlToNdi.Video;
+using Xunit;
+
+namespace Tractus.HtmlToNdi.Tests;
+
+internal static class FrameTestHelper
+{
+    internal static VideoFrame CreateFrame(byte fillValue, int width = 2, int height = 2)
+    {
+        var stride = width * 4;
+        var buffer = Enumerable.Repeat(fillValue, stride * height).Select(v => (byte)v).ToArray();
+        return VideoFrame.FromSpan(buffer, width, height, stride, DateTime.UtcNow);
+    }
+}
+
+public class FrameRingBufferTests
+{
+    [Fact]
+    public void ReadLatest_ReturnsMostRecentFrameAndDropCount()
+    {
+        using var buffer = new FrameRingBuffer(3);
+
+        var firstRead = buffer.ReadLatest(0);
+        Assert.False(firstRead.HasFrame);
+
+        using var first = FrameTestHelper.CreateFrame(1);
+        buffer.Enqueue(first);
+
+        var afterFirst = buffer.ReadLatest(0);
+        Assert.True(afterFirst.HasFrame);
+        Assert.Equal(1, afterFirst.Sequence);
+        Assert.Equal(0, afterFirst.DroppedCount);
+
+        using var second = FrameTestHelper.CreateFrame(2);
+        using var third = FrameTestHelper.CreateFrame(3);
+        buffer.Enqueue(second);
+        buffer.Enqueue(third);
+
+        using var newest = FrameTestHelper.CreateFrame(4);
+        buffer.Enqueue(newest);
+
+        var latest = buffer.ReadLatest(afterFirst.Sequence);
+        Assert.True(latest.HasFrame);
+        Assert.Equal(4, latest.Sequence);
+        Assert.Equal(2, latest.DroppedCount);
+        Assert.Same(newest, latest.Frame);
+    }
+}
+
+public class FramePacerTests
+{
+    [Fact]
+    public void RunTick_RepeatsFrameWhenNoNewFrameArrives()
+    {
+        using var buffer = new FrameRingBuffer(3);
+        var dispatched = new List<FrameDispatch>();
+        using var pacer = new FramePacer(buffer, FrameRate.FromDouble(30), dispatched.Add, new FramePacerOptions { StartImmediately = false, MetricsLogInterval = TimeSpan.Zero });
+
+        using var frame = FrameTestHelper.CreateFrame(1);
+        buffer.Enqueue(frame);
+
+        var now = DateTime.UtcNow;
+        pacer.RunTick(now);
+        pacer.RunTick(now + pacer.TargetInterval);
+
+        Assert.Equal(2, dispatched.Count);
+        Assert.False(dispatched[0].IsRepeat);
+        Assert.True(dispatched[1].IsRepeat);
+        Assert.Equal(frame, dispatched[0].Frame);
+        Assert.Equal(frame, dispatched[1].Frame);
+    }
+
+    [Fact]
+    public void RunTick_DropsIntermediateFrames()
+    {
+        using var buffer = new FrameRingBuffer(3);
+        var dispatched = new List<FrameDispatch>();
+        using var pacer = new FramePacer(buffer, FrameRate.FromDouble(30), dispatched.Add, new FramePacerOptions { StartImmediately = false, MetricsLogInterval = TimeSpan.Zero });
+
+        using var first = FrameTestHelper.CreateFrame(1);
+        buffer.Enqueue(first);
+
+        var now = DateTime.UtcNow;
+        pacer.RunTick(now);
+
+        using var second = FrameTestHelper.CreateFrame(2);
+        using var third = FrameTestHelper.CreateFrame(3);
+        using var fourth = FrameTestHelper.CreateFrame(4);
+        buffer.Enqueue(second);
+        buffer.Enqueue(third);
+        buffer.Enqueue(fourth);
+
+        pacer.RunTick(now + pacer.TargetInterval);
+
+        Assert.Equal(2, dispatched.Count);
+        Assert.False(dispatched[1].IsRepeat);
+        Assert.Equal(2, dispatched[1].DroppedFrames);
+        Assert.Equal(fourth, dispatched[1].Frame);
+    }
+}

--- a/Tests/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
+++ b/Tests/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Tractus.HtmlToNdi.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tractus.HtmlToNdi.sln
+++ b/Tractus.HtmlToNdi.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.11.35303.130
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tractus.HtmlToNdi", "Tractus.HtmlToNdi.csproj", "{6B6C038D-3984-455A-95CA-A9079B3FC4E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tractus.HtmlToNdi.Tests", "Tests\Tractus.HtmlToNdi.Tests\Tractus.HtmlToNdi.Tests.csproj", "{EE6E38ED-DFBA-4BDC-9423-BBDFAC8A2818}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,8 +22,16 @@ Global
 		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.ActiveCfg = Release|x64
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.Build.0 = Release|x64
-	EndGlobalSection
+                {6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.Build.0 = Release|x64
+                {EE6E38ED-DFBA-4BDC-9423-BBDFAC8A2818}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {EE6E38ED-DFBA-4BDC-9423-BBDFAC8A2818}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {EE6E38ED-DFBA-4BDC-9423-BBDFAC8A2818}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {EE6E38ED-DFBA-4BDC-9423-BBDFAC8A2818}.Debug|x64.Build.0 = Debug|Any CPU
+                {EE6E38ED-DFBA-4BDC-9423-BBDFAC8A2818}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {EE6E38ED-DFBA-4BDC-9423-BBDFAC8A2818}.Release|Any CPU.Build.0 = Release|Any CPU
+                {EE6E38ED-DFBA-4BDC-9423-BBDFAC8A2818}.Release|x64.ActiveCfg = Release|Any CPU
+                {EE6E38ED-DFBA-4BDC-9423-BBDFAC8A2818}.Release|x64.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Video/FrameDispatch.cs
+++ b/Video/FrameDispatch.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public readonly struct FrameDispatch
+{
+    public FrameDispatch(VideoFrame frame, bool isRepeat, int droppedFrames, TimeSpan actualInterval, DateTime dispatchTimeUtc)
+    {
+        this.Frame = frame ?? throw new ArgumentNullException(nameof(frame));
+        this.IsRepeat = isRepeat;
+        this.DroppedFrames = droppedFrames;
+        this.ActualInterval = actualInterval;
+        this.DispatchTimeUtc = dispatchTimeUtc;
+    }
+
+    public VideoFrame Frame { get; }
+
+    public bool IsRepeat { get; }
+
+    public int DroppedFrames { get; }
+
+    public TimeSpan ActualInterval { get; }
+
+    public DateTime DispatchTimeUtc { get; }
+}

--- a/Video/FramePacer.cs
+++ b/Video/FramePacer.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using Serilog;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public sealed class FramePacer : IDisposable
+{
+    private readonly FrameRingBuffer buffer;
+    private readonly FrameRate targetFrameRate;
+    private readonly Action<FrameDispatch> frameConsumer;
+    private readonly FramePacerOptions options;
+    private readonly object stateLock = new();
+    private readonly Stopwatch stopwatch = new();
+
+    private Thread? workerThread;
+    private volatile bool running;
+    private bool disposed;
+    private VideoFrame? currentFrame;
+    private long lastSequence;
+    private DateTime lastTickUtc = DateTime.MinValue;
+    private DateTime lastLogUtc = DateTime.MinValue;
+
+    private long sentFrames;
+    private long repeatedFrames;
+    private long droppedFrames;
+    private double minIntervalMs = double.MaxValue;
+    private double maxIntervalMs;
+    private double accumulatedIntervalMs;
+
+    public FramePacer(FrameRingBuffer buffer, FrameRate targetFrameRate, Action<FrameDispatch> frameConsumer, FramePacerOptions? options = null)
+    {
+        this.buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+        this.targetFrameRate = targetFrameRate;
+        this.frameConsumer = frameConsumer ?? throw new ArgumentNullException(nameof(frameConsumer));
+        this.options = options ?? new FramePacerOptions();
+
+        if (this.options.StartImmediately)
+        {
+            this.Start();
+        }
+    }
+
+    public TimeSpan TargetInterval => this.targetFrameRate.FrameInterval;
+
+    public void Start()
+    {
+        lock (this.stateLock)
+        {
+            if (this.running)
+            {
+                return;
+            }
+
+            this.running = true;
+            this.workerThread = new Thread(this.Run)
+            {
+                Name = "FramePacer",
+                IsBackground = true,
+                Priority = ThreadPriority.AboveNormal,
+            };
+
+            this.workerThread.Start();
+        }
+    }
+
+    public void Stop()
+    {
+        lock (this.stateLock)
+        {
+            this.running = false;
+        }
+
+        if (this.workerThread is not null && Thread.CurrentThread != this.workerThread)
+        {
+            this.workerThread.Join();
+            this.workerThread = null;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (this.disposed)
+        {
+            return;
+        }
+
+        this.Stop();
+        this.currentFrame?.Dispose();
+        this.currentFrame = null;
+        this.disposed = true;
+    }
+
+    internal void RunTick(DateTime utcNow)
+    {
+        var actualInterval = this.lastTickUtc == DateTime.MinValue ? this.TargetInterval : utcNow - this.lastTickUtc;
+        this.lastTickUtc = utcNow;
+
+        var readResult = this.buffer.ReadLatest(this.lastSequence);
+
+        VideoFrame? frameToSend = null;
+        var isRepeat = false;
+        var dropped = 0;
+
+        if (readResult.HasFrame)
+        {
+            var latestFrame = readResult.Frame!;
+            latestFrame.AddReference();
+            this.currentFrame?.Dispose();
+            this.currentFrame = latestFrame;
+            this.lastSequence = readResult.Sequence;
+            dropped = readResult.DroppedCount;
+            frameToSend = latestFrame;
+        }
+        else if (this.currentFrame is not null)
+        {
+            frameToSend = this.currentFrame;
+            isRepeat = true;
+        }
+
+        if (frameToSend is null)
+        {
+            return;
+        }
+
+        try
+        {
+            this.frameConsumer(new FrameDispatch(frameToSend, isRepeat, dropped, actualInterval, utcNow));
+        }
+        catch (Exception ex)
+        {
+            Log.Logger.Error(ex, "Error while processing paced frame");
+        }
+
+        this.sentFrames++;
+        if (isRepeat)
+        {
+            this.repeatedFrames++;
+        }
+
+        this.droppedFrames += dropped;
+        this.TrackInterval(actualInterval);
+        this.LogMetricsIfNeeded(utcNow);
+    }
+
+    private void Run()
+    {
+        this.stopwatch.Restart();
+        var nextDeadline = this.stopwatch.Elapsed;
+
+        while (true)
+        {
+            if (!this.running)
+            {
+                break;
+            }
+
+            nextDeadline += this.TargetInterval;
+            this.SleepUntil(nextDeadline);
+
+            if (!this.running)
+            {
+                break;
+            }
+
+            this.RunTick(DateTime.UtcNow);
+        }
+    }
+
+    private void SleepUntil(TimeSpan target)
+    {
+        while (true)
+        {
+            var remaining = target - this.stopwatch.Elapsed;
+            if (remaining <= TimeSpan.Zero)
+            {
+                return;
+            }
+
+            if (remaining > TimeSpan.FromMilliseconds(2))
+            {
+                Thread.Sleep(remaining - TimeSpan.FromMilliseconds(1));
+            }
+            else
+            {
+                Thread.SpinWait(50);
+            }
+        }
+    }
+
+    private void TrackInterval(TimeSpan interval)
+    {
+        var intervalMs = interval.TotalMilliseconds;
+        this.accumulatedIntervalMs += intervalMs;
+        this.minIntervalMs = Math.Min(this.minIntervalMs, intervalMs);
+        this.maxIntervalMs = Math.Max(this.maxIntervalMs, intervalMs);
+    }
+
+    private void LogMetricsIfNeeded(DateTime utcNow)
+    {
+        if (this.options.MetricsLogInterval <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        if (this.lastLogUtc != DateTime.MinValue && utcNow - this.lastLogUtc < this.options.MetricsLogInterval)
+        {
+            return;
+        }
+
+        if (this.sentFrames == 0)
+        {
+            return;
+        }
+
+        var avg = this.accumulatedIntervalMs / this.sentFrames;
+        Log.Information(
+            "Frame pacing stats: sent={Sent} repeat={Repeat} dropped={Dropped} interval_avg={Avg:F3}ms interval_min={Min:F3}ms interval_max={Max:F3}ms target={Target:F3}ms buffer_depth={BufferDepth}",
+            this.sentFrames,
+            this.repeatedFrames,
+            this.droppedFrames,
+            avg,
+            this.minIntervalMs,
+            this.maxIntervalMs,
+            this.TargetInterval.TotalMilliseconds,
+            this.buffer.Capacity);
+
+        this.lastLogUtc = utcNow;
+        this.sentFrames = 0;
+        this.repeatedFrames = 0;
+        this.droppedFrames = 0;
+        this.accumulatedIntervalMs = 0;
+        this.minIntervalMs = double.MaxValue;
+        this.maxIntervalMs = 0;
+    }
+}

--- a/Video/FramePacer.cs
+++ b/Video/FramePacer.cs
@@ -106,7 +106,6 @@ public sealed class FramePacer : IDisposable
         if (readResult.HasFrame)
         {
             var latestFrame = readResult.Frame!;
-            latestFrame.AddReference();
             this.currentFrame?.Dispose();
             this.currentFrame = latestFrame;
             this.lastSequence = readResult.Sequence;

--- a/Video/FramePacerOptions.cs
+++ b/Video/FramePacerOptions.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public sealed class FramePacerOptions
+{
+    public bool StartImmediately { get; set; } = true;
+
+    public TimeSpan MetricsLogInterval { get; set; } = TimeSpan.FromSeconds(5);
+}

--- a/Video/FrameRate.cs
+++ b/Video/FrameRate.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Globalization;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public readonly struct FrameRate
+{
+    public int Numerator { get; }
+
+    public int Denominator { get; }
+
+    public double FramesPerSecond => (double)this.Numerator / this.Denominator;
+
+    public TimeSpan FrameInterval => TimeSpan.FromSeconds((double)this.Denominator / this.Numerator);
+
+    private FrameRate(int numerator, int denominator)
+    {
+        if (numerator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(numerator));
+        }
+
+        if (denominator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(denominator));
+        }
+
+        this.Numerator = numerator;
+        this.Denominator = denominator;
+    }
+
+    public static FrameRate Create(int numerator, int denominator)
+    {
+        var gcd = GreatestCommonDivisor(Math.Abs(numerator), Math.Abs(denominator));
+        return new FrameRate(numerator / gcd, denominator / gcd);
+    }
+
+    public static FrameRate FromDouble(double framesPerSecond, int precision = 1000)
+    {
+        if (framesPerSecond <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(framesPerSecond));
+        }
+
+        var denominator = Math.Max(1, precision);
+        var numerator = (int)Math.Round(framesPerSecond * denominator, MidpointRounding.AwayFromZero);
+
+        if (numerator == 0)
+        {
+            numerator = 1;
+        }
+
+        return Create(numerator, denominator);
+    }
+
+    public static bool TryParse(string value, out FrameRate frameRate)
+    {
+        frameRate = default;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        value = value.Trim();
+        if (value.Contains('/', StringComparison.Ordinal))
+        {
+            var parts = value.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length != 2)
+            {
+                return false;
+            }
+
+            if (int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var numerator)
+                && int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var denominator))
+            {
+                frameRate = Create(numerator, denominator);
+                return true;
+            }
+
+            return false;
+        }
+
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var fps))
+        {
+            frameRate = FromDouble(fps);
+            return true;
+        }
+
+        return false;
+    }
+
+    public override string ToString()
+    {
+        return $"{this.Numerator}/{this.Denominator} ({this.FramesPerSecond:F3} fps)";
+    }
+
+    public static FrameRate Ntsc2997 { get; } = Create(30000, 1001);
+
+    private static int GreatestCommonDivisor(int a, int b)
+    {
+        while (b != 0)
+        {
+            var temp = b;
+            b = a % b;
+            a = temp;
+        }
+
+        return a == 0 ? 1 : a;
+    }
+}

--- a/Video/FrameRingBuffer.cs
+++ b/Video/FrameRingBuffer.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Threading;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public sealed class FrameRingBuffer : IDisposable
+{
+    private readonly VideoFrame?[] slots;
+    private readonly int capacity;
+    private long writeSequence;
+    private long publishedSequence;
+
+    public FrameRingBuffer(int capacity)
+    {
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity));
+        }
+
+        this.capacity = capacity;
+        this.slots = new VideoFrame?[capacity];
+        this.writeSequence = 0;
+        this.publishedSequence = 0;
+    }
+
+    public int Capacity => this.capacity;
+
+    public long Enqueue(VideoFrame frame)
+    {
+        if (frame is null)
+        {
+            throw new ArgumentNullException(nameof(frame));
+        }
+
+        var sequence = Interlocked.Increment(ref this.writeSequence);
+        var index = (int)((sequence - 1) % this.capacity);
+        frame.AddReference();
+        var previous = Interlocked.Exchange(ref this.slots[index], frame);
+        previous?.Dispose();
+        Volatile.Write(ref this.publishedSequence, sequence);
+        return sequence;
+    }
+
+    public FrameReadResult ReadLatest(long lastSequence)
+    {
+        var current = Volatile.Read(ref this.publishedSequence);
+        if (current == 0 || current == lastSequence)
+        {
+            return FrameReadResult.Empty(lastSequence);
+        }
+
+        var index = (int)((current - 1) % this.capacity);
+        var frame = Volatile.Read(ref this.slots[index]);
+        if (frame is null)
+        {
+            return FrameReadResult.Empty(lastSequence);
+        }
+
+        var dropped = lastSequence == 0 ? 0 : (int)Math.Max(0, current - lastSequence - 1);
+        return FrameReadResult.WithFrame(frame, current, dropped);
+    }
+
+    public void Dispose()
+    {
+        for (var i = 0; i < this.slots.Length; i++)
+        {
+            Interlocked.Exchange(ref this.slots[i], null)?.Dispose();
+        }
+    }
+
+    public readonly struct FrameReadResult
+    {
+        private FrameReadResult(VideoFrame? frame, long sequence, int dropped)
+        {
+            this.Frame = frame;
+            this.Sequence = sequence;
+            this.DroppedCount = dropped;
+        }
+
+        public VideoFrame? Frame { get; }
+
+        public long Sequence { get; }
+
+        public int DroppedCount { get; }
+
+        public bool HasFrame => this.Frame is not null;
+
+        public static FrameReadResult Empty(long sequence) => new(null, sequence, 0);
+
+        public static FrameReadResult WithFrame(VideoFrame frame, long sequence, int dropped) => new(frame, sequence, dropped);
+    }
+}

--- a/Video/VideoFrame.cs
+++ b/Video/VideoFrame.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public sealed class VideoFrame : IDisposable
+{
+    private readonly IMemoryOwner<byte> memoryOwner;
+    private bool disposed;
+    private int referenceCount;
+
+    private VideoFrame(IMemoryOwner<byte> memoryOwner, int length, int width, int height, int stride, DateTime capturedAtUtc)
+    {
+        this.memoryOwner = memoryOwner;
+        this.Length = length;
+        this.Width = width;
+        this.Height = height;
+        this.Stride = stride;
+        this.CapturedAtUtc = capturedAtUtc;
+        this.referenceCount = 1;
+    }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public int Stride { get; }
+
+    public int Length { get; }
+
+    public DateTime CapturedAtUtc { get; }
+
+    public ReadOnlySpan<byte> GetSpan()
+    {
+        this.ThrowIfDisposed();
+        return this.memoryOwner.Memory.Span[..this.Length];
+    }
+
+    public unsafe void WithPointer(Action<IntPtr> action)
+    {
+        this.ThrowIfDisposed();
+
+        var span = this.memoryOwner.Memory.Span.Slice(0, this.Length);
+        ref var reference = ref MemoryMarshal.GetReference(span);
+
+        fixed (byte* pointer = &reference)
+        {
+            action((IntPtr)pointer);
+        }
+    }
+
+    public void AddReference()
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref this.referenceCount);
+            if (current == 0)
+            {
+                throw new ObjectDisposedException(nameof(VideoFrame));
+            }
+
+            if (Interlocked.CompareExchange(ref this.referenceCount, current + 1, current) == current)
+            {
+                return;
+            }
+        }
+    }
+
+    public static VideoFrame FromPointer(IntPtr sourcePointer, int width, int height, int stride, DateTime capturedAtUtc)
+    {
+        if (sourcePointer == IntPtr.Zero)
+        {
+            throw new ArgumentNullException(nameof(sourcePointer));
+        }
+
+        var length = stride * height;
+        var source = new ReadOnlySpan<byte>((void*)sourcePointer, length);
+        return FromSpan(source, width, height, stride, capturedAtUtc);
+    }
+
+    public static VideoFrame FromSpan(ReadOnlySpan<byte> source, int width, int height, int stride, DateTime capturedAtUtc)
+    {
+        if (stride <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(stride));
+        }
+
+        var expectedLength = stride * height;
+        if (source.Length < expectedLength)
+        {
+            throw new ArgumentException("Source buffer is smaller than expected frame size.", nameof(source));
+        }
+
+        var owner = MemoryPool<byte>.Shared.Rent(expectedLength);
+        source[..expectedLength].CopyTo(owner.Memory.Span.Slice(0, expectedLength));
+        return new VideoFrame(owner, expectedLength, width, height, stride, capturedAtUtc);
+    }
+
+    public void Dispose()
+    {
+        if (this.disposed)
+        {
+            return;
+        }
+
+        var newCount = Interlocked.Decrement(ref this.referenceCount);
+        if (newCount < 0)
+        {
+            throw new ObjectDisposedException(nameof(VideoFrame));
+        }
+
+        if (newCount == 0)
+        {
+            this.memoryOwner.Dispose();
+            this.disposed = true;
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (this.disposed)
+        {
+            throw new ObjectDisposedException(nameof(VideoFrame));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable Video frame pacing subsystem (ring buffer, pacer, frame metadata)
- update Program and CefWrapper to use the pacing pipeline and expose CLI options for fps, buffer depth, and Chromium flags
- document the new behaviour in README/AGENTS and add xUnit tests for the ring buffer and pacer

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da3e938c00832997ab856c513e080b