### PR TITLE
Add frame pump with optional buffered pacing

### DIFF
--- a/Chromium/FrameBufferPipeline.cs
+++ b/Chromium/FrameBufferPipeline.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Buffers;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using NewTek;
+using Serilog;
+
+namespace Tractus.HtmlToNdi.Chromium;
+
+internal sealed class FrameBufferPipeline : IDisposable
+{
+    private readonly int width;
+    private readonly int height;
+    private readonly int stride;
+    private readonly int frameRate;
+    private readonly Channel<VideoFrame> channel;
+    private readonly CancellationTokenSource cancellationTokenSource = new();
+    private readonly Task pacerTask;
+    private VideoFrame? lastFrame;
+    private long droppedFrameCount;
+
+    public FrameBufferPipeline(int width, int height, int frameRate, int capacity)
+    {
+        if (width <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width));
+        }
+
+        if (height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(height));
+        }
+
+        if (frameRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(frameRate));
+        }
+
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity));
+        }
+
+        this.width = width;
+        this.height = height;
+        this.stride = width * 4;
+        this.frameRate = frameRate;
+        this.channel = Channel.CreateBounded<VideoFrame>(new BoundedChannelOptions(capacity)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = false
+        });
+
+        this.pacerTask = Task.Factory.StartNew(
+            this.PacerLoopAsync,
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default).Unwrap();
+    }
+
+    public void Enqueue(nint bufferHandle)
+    {
+        if (this.cancellationTokenSource.IsCancellationRequested)
+        {
+            return;
+        }
+
+        var frame = VideoFrame.Rent(this.width, this.height, this.stride);
+        try
+        {
+            frame.FillFrom(bufferHandle);
+        }
+        catch
+        {
+            frame.Dispose();
+            throw;
+        }
+
+        if (!this.channel.Writer.TryWrite(frame))
+        {
+            frame.Dispose();
+            Interlocked.Increment(ref this.droppedFrameCount);
+        }
+    }
+
+    private async Task PacerLoopAsync()
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1d / this.frameRate));
+        try
+        {
+            while (await timer.WaitForNextTickAsync(this.cancellationTokenSource.Token).ConfigureAwait(false))
+            {
+                if (Program.NdiSenderPtr == nint.Zero)
+                {
+                    continue;
+                }
+
+                VideoFrame? frameToSend = null;
+                if (this.channel.Reader.TryRead(out var nextFrame))
+                {
+                    frameToSend = nextFrame;
+                }
+                else if (this.lastFrame is not null)
+                {
+                    frameToSend = this.lastFrame;
+                }
+
+                if (frameToSend is null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    frameToSend.SendToNdi(Program.NdiSenderPtr, this.frameRate);
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "Failed to send buffered frame to NDI");
+                }
+
+                if (!ReferenceEquals(frameToSend, this.lastFrame))
+                {
+                    this.lastFrame?.Dispose();
+                    this.lastFrame = frameToSend;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during shutdown.
+        }
+        finally
+        {
+            this.channel.Writer.TryComplete();
+            while (this.channel.Reader.TryRead(out var frame))
+            {
+                frame.Dispose();
+            }
+
+            this.lastFrame?.Dispose();
+            this.lastFrame = null;
+
+            var dropped = Interlocked.Read(ref this.droppedFrameCount);
+            if (dropped > 0)
+            {
+                Log.Information("Buffered video pipeline dropped {Dropped} frames due to back-pressure.", dropped);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        this.cancellationTokenSource.Cancel();
+        try
+        {
+            this.pacerTask.GetAwaiter().GetResult();
+        }
+        catch
+        {
+            // Ignore exceptions from shutdown.
+        }
+        finally
+        {
+            this.cancellationTokenSource.Dispose();
+        }
+    }
+
+    private sealed class VideoFrame : IDisposable
+    {
+        private static readonly ArrayPool<byte> Pool = ArrayPool<byte>.Shared;
+        private byte[]? buffer;
+        private readonly int width;
+        private readonly int height;
+        private readonly int stride;
+        private readonly int length;
+
+        private VideoFrame(byte[] buffer, int width, int height, int stride)
+        {
+            this.buffer = buffer;
+            this.width = width;
+            this.height = height;
+            this.stride = stride;
+            this.length = height * stride;
+        }
+
+        public static VideoFrame Rent(int width, int height, int stride)
+        {
+            var buffer = Pool.Rent(height * stride);
+            return new VideoFrame(buffer, width, height, stride);
+        }
+
+        public void FillFrom(nint source)
+        {
+            if (this.buffer is null)
+            {
+                throw new ObjectDisposedException(nameof(VideoFrame));
+            }
+
+            System.Runtime.InteropServices.Marshal.Copy(source, this.buffer, 0, this.length);
+        }
+
+        public unsafe void SendToNdi(nint senderPtr, int frameRate)
+        {
+            if (this.buffer is null)
+            {
+                throw new ObjectDisposedException(nameof(VideoFrame));
+            }
+
+            fixed (byte* ptr = this.buffer)
+            {
+                var videoFrame = new NDIlib.video_frame_v2_t
+                {
+                    FourCC = NDIlib.FourCC_type_e.FourCC_type_BGRA,
+                    frame_rate_N = frameRate,
+                    frame_rate_D = 1,
+                    frame_format_type = NDIlib.frame_format_type_e.frame_format_type_progressive,
+                    line_stride_in_bytes = this.stride,
+                    picture_aspect_ratio = (float)this.width / this.height,
+                    p_data = (nint)ptr,
+                    timecode = NDIlib.send_timecode_synthesize,
+                    xres = this.width,
+                    yres = this.height,
+                };
+
+                NDIlib.send_send_video_v2(senderPtr, ref videoFrame);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (this.buffer is not null)
+            {
+                Pool.Return(this.buffer);
+                this.buffer = null;
+            }
+        }
+    }
+}

--- a/Chromium/FramePump.cs
+++ b/Chromium/FramePump.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CefSharp.OffScreen;
+
+namespace Tractus.HtmlToNdi.Chromium;
+
+internal sealed class FramePump : IDisposable
+{
+    private readonly ChromiumWebBrowser browser;
+    private readonly TimeSpan interval;
+    private readonly CancellationTokenSource cancellationTokenSource = new();
+    private readonly Task pumpTask;
+
+    public FramePump(ChromiumWebBrowser browser, int frameRate)
+    {
+        this.browser = browser ?? throw new ArgumentNullException(nameof(browser));
+        if (frameRate <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(frameRate), frameRate, "Frame rate must be positive.");
+        }
+
+        this.interval = TimeSpan.FromSeconds(1d / frameRate);
+        this.pumpTask = Task.Factory.StartNew(
+            this.PumpAsync,
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default).Unwrap();
+    }
+
+    private async Task PumpAsync()
+    {
+        using var timer = new PeriodicTimer(this.interval);
+
+        try
+        {
+            while (await timer.WaitForNextTickAsync(this.cancellationTokenSource.Token).ConfigureAwait(false))
+            {
+                try
+                {
+                    this.browser.GetBrowserHost()?.Invalidate(CefSharp.PaintElementType.View);
+                }
+                catch
+                {
+                    // Swallow exceptions to keep pacing alive; Chromium may already be shutting down.
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during shutdown.
+        }
+    }
+
+    public void Dispose()
+    {
+        this.cancellationTokenSource.Cancel();
+        try
+        {
+            this.pumpTask.GetAwaiter().GetResult();
+        }
+        catch
+        {
+            // Ignore failures from Chromium tearing down concurrently.
+        }
+        finally
+        {
+            this.cancellationTokenSource.Dispose();
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,6 @@
 
+using System;
+using System.Linq;
 using CefSharp;
 using CefSharp.OffScreen;
 using Microsoft.AspNetCore.Builder;
@@ -95,6 +97,8 @@ public class Program
 
         var width = 1920;
         var height = 1080;
+        var frameRate = 60;
+        var frameBufferCapacity = 0;
 
         if (args.Any(x => x.StartsWith("--w")))
         {
@@ -122,6 +126,37 @@ public class Program
             }
         }
 
+        if (args.Any(x => x.StartsWith("--fps")))
+        {
+            try
+            {
+                frameRate = int.Parse(args.FirstOrDefault(x => x.StartsWith("--fps")).Split("=")[1]);
+                if (frameRate <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(frameRate));
+                }
+            }
+            catch (Exception)
+            {
+                Log.Error("Could not parse the --fps parameter. Exiting.");
+                return;
+            }
+        }
+
+        if (args.Any(x => x.StartsWith("--frame-buffer")))
+        {
+            try
+            {
+                frameBufferCapacity = int.Parse(args.FirstOrDefault(x => x.StartsWith("--frame-buffer")).Split("=")[1]);
+                frameBufferCapacity = Math.Max(frameBufferCapacity, 0);
+            }
+            catch (Exception)
+            {
+                Log.Error("Could not parse the --frame-buffer parameter. Exiting.");
+                return;
+            }
+        }
+
         AsyncContext.Run(async delegate
         {
             var settings = new CefSettings();
@@ -143,7 +178,9 @@ public class Program
             browserWrapper = new CefWrapper(
                 width,
                 height,
-                startUrl);
+                startUrl,
+                frameRate,
+                frameBufferCapacity);
 
             await browserWrapper.InitializeWrapperAsync();
         });

--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ If the web page you are loading has a transparent background, NDI will honor tha
 Parameter|Description
 ----|---
 `--ndiname="NDI Source Name"`|The source name this browser instance will send. Defaults to "`HTML5`".
-`--width=1920`|The width of the browser source. Defaults to `1920`.
-`--width=1080`|The height of the browser source. Defaults to `1080`.
+`--w=1920`|The width of the browser source. Defaults to `1920`.
+`--h=1080`|The height of the browser source. Defaults to `1080`.
 `--port=9999`|The port the HTTP server will listen on. Defaults to `9999`.
 `--url="https://www.tractus.ca"`|The startup webpage. Defaults to `https://testpattern.tractusevents.com/`.
+`--fps=60`|Target rendering cadence for Chromium and the advertised NDI frame rate. Defaults to `60`.
+`--frame-buffer=0`|Optional buffered frame queue depth. `0` keeps the zero-copy pipeline, `>0` enables paced buffering with the specified queue length.
 
 #### Example Launch
 
-`.\Tractus.HtmlToNdi.exe --ndiname="HTML 5 Test" --w=1080 --h=1080 --url="https://testpattern.tractusevents.com"`
+`.\Tractus.HtmlToNdi.exe --ndiname="HTML 5 Test" --w=1080 --h=1080 --fps=60 --url="https://testpattern.tractusevents.com"`
 
 ## API Routes
 
@@ -35,7 +37,7 @@ Route|Method|Description|Example
 - Frames are sent to NDI in RGBA format. Some machines may experience a slight performance penalty.
 - H.264 and any other non-free codecs are not available for video playback since this uses Chromium. Sites like YouTube likely won't work.
 - Audio data received from the browser is passed to NDI directly.
-- NDI frame rate is set to 60 frames per second. The internal max render frame rate is set to be capped at 60 frames per second.
+- NDI frame rate defaults to 60 frames per second but can be overridden with `--fps`. When buffering is enabled the pacer also runs at that cadence.
 
 ## More Tools
 


### PR DESCRIPTION
## Summary
- add a dedicated frame pump so Chromium invalidates at the configured FPS before handing frames to NDI
- introduce an optional pooled frame buffer and pacer that smooths delivery when `--frame-buffer` is set
- document the new CLI switches and update the project briefing to reflect the combined pacing strategies

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da4d534c048329ad9d15c5b0dcca55