### PR TITLE
Add paced NDI pipeline with buffering telemetry and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,16 @@ If the web page you are loading has a transparent background, NDI will honor tha
 
 Parameter|Description
 ----|---
-`--ndiname="NDI Source Name"`|The source name this browser instance will send. Defaults to "`HTML5`".
-`--width=1920`|The width of the browser source. Defaults to `1920`.
-`--width=1080`|The height of the browser source. Defaults to `1080`.
-`--port=9999`|The port the HTTP server will listen on. Defaults to `9999`.
+`--ndiname="NDI Source Name"`|Sets the NDI source name. Defaults to `HTML5` if omitted.
+`--w=1920`|The width of the browser surface in pixels. Defaults to `1920`.
+`--h=1080`|The height of the browser surface in pixels. Defaults to `1080`.
+`--port=9999`|Port for the HTTP control API. When omitted the app will prompt.
 `--url="https://www.tractus.ca"`|The startup webpage. Defaults to `https://testpattern.tractusevents.com/`.
+`--fps=59.94`|Target NDI frame rate. Accepts decimals (`59.94`) or rationals (`60000/1001`). Defaults to `60`.
+`--buffer-depth=3`|Enables the paced output buffer with the specified depth (frames). Set to `0` or omit to disable buffering.
+`--enable-output-buffer`|Shorthand to enable buffering with a default depth of `3` frames.
+`--windowless-frame-rate=60`|Overrides Chromium's internal frame pump. Defaults to the rounded `--fps` value.
+`--disable-vsync`|Passes `--disable-gpu-vsync` to Chromium for workloads that prefer uncapped rendering.
 
 #### Example Launch
 
@@ -35,7 +40,7 @@ Route|Method|Description|Example
 - Frames are sent to NDI in RGBA format. Some machines may experience a slight performance penalty.
 - H.264 and any other non-free codecs are not available for video playback since this uses Chromium. Sites like YouTube likely won't work.
 - Audio data received from the browser is passed to NDI directly.
-- NDI frame rate is set to 60 frames per second. The internal max render frame rate is set to be capped at 60 frames per second.
+- When buffering is enabled the app logs pacing metrics (measured fps, drops, repeats) and publishes them as NDI metadata.
 
 ## More Tools
 

--- a/Tractus.HtmlToNdi.Tests/FramePipelineTests.cs
+++ b/Tractus.HtmlToNdi.Tests/FramePipelineTests.cs
@@ -1,0 +1,58 @@
+using System;
+using Tractus.HtmlToNdi.Video;
+using Xunit;
+
+namespace Tractus.HtmlToNdi.Tests;
+
+public class FramePipelineTests
+{
+    [Fact]
+    public void FrameRingBuffer_DropsOldestAndKeepsNewest()
+    {
+        var buffer = new FrameRingBuffer(2);
+        var first = BufferedVideoFrame.Rent(16);
+        first.Populate(2, 2, 8, DateTime.UtcNow);
+        var second = BufferedVideoFrame.Rent(16);
+        second.Populate(2, 2, 8, DateTime.UtcNow.AddMilliseconds(16));
+        var third = BufferedVideoFrame.Rent(16);
+        third.Populate(2, 2, 8, DateTime.UtcNow.AddMilliseconds(32));
+
+        buffer.Enqueue(first);
+        buffer.Enqueue(second);
+        buffer.Enqueue(third);
+
+        Assert.Equal(1, buffer.DroppedFrames);
+
+        using var latest = buffer.TakeLatest();
+        Assert.NotNull(latest);
+        Assert.Equal(third.TimestampUtc, latest!.TimestampUtc);
+
+        buffer.Clear();
+    }
+
+    [Fact]
+    public void FrameTimeAverager_ComputesAverageFps()
+    {
+        var averager = new FrameTimeAverager(10);
+        var start = DateTime.UtcNow;
+        for (var i = 0; i < 6; i++)
+        {
+            averager.AddSample(start.AddMilliseconds(16.67 * i));
+        }
+
+        var fps = averager.GetAverageFps();
+        Assert.InRange(fps, 59.0, 61.0);
+    }
+
+    [Theory]
+    [InlineData("59.94", 60000, 1001)]
+    [InlineData("60000/1001", 60000, 1001)]
+    [InlineData("30000:1001", 30000, 1001)]
+    [InlineData("50", 50, 1)]
+    public void FrameRate_ParsesInputs(string input, int expectedN, int expectedD)
+    {
+        var rate = FrameRate.Parse(input);
+        Assert.Equal(expectedN, rate.Numerator);
+        Assert.Equal(expectedD, rate.Denominator);
+    }
+}

--- a/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
+++ b/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Tractus.HtmlToNdi.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tractus.HtmlToNdi.sln
+++ b/Tractus.HtmlToNdi.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.11.35303.130
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tractus.HtmlToNdi", "Tractus.HtmlToNdi.csproj", "{6B6C038D-3984-455A-95CA-A9079B3FC4E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tractus.HtmlToNdi.Tests", "Tractus.HtmlToNdi.Tests\\Tractus.HtmlToNdi.Tests.csproj", "{716CBECF-C13F-40CD-B285-4528A2DF8116}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,11 +19,19 @@ Global
 		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|x64.ActiveCfg = Debug|x64
 		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|x64.Build.0 = Debug|x64
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.ActiveCfg = Release|x64
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.Build.0 = Release|x64
-	EndGlobalSection
+                {6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.Build.0 = Release|Any CPU
+                {6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.ActiveCfg = Release|x64
+                {6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.Build.0 = Release|x64
+                {716CBECF-C13F-40CD-B285-4528A2DF8116}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {716CBECF-C13F-40CD-B285-4528A2DF8116}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {716CBECF-C13F-40CD-B285-4528A2DF8116}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {716CBECF-C13F-40CD-B285-4528A2DF8116}.Debug|x64.Build.0 = Debug|Any CPU
+                {716CBECF-C13F-40CD-B285-4528A2DF8116}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {716CBECF-C13F-40CD-B285-4528A2DF8116}.Release|Any CPU.Build.0 = Release|Any CPU
+                {716CBECF-C13F-40CD-B285-4528A2DF8116}.Release|x64.ActiveCfg = Release|Any CPU
+                {716CBECF-C13F-40CD-B285-4528A2DF8116}.Release|x64.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Video/BufferedVideoFrame.cs
+++ b/Video/BufferedVideoFrame.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Buffers;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public sealed class BufferedVideoFrame : IDisposable
+{
+    private readonly IMemoryOwner<byte> memoryOwner;
+    private bool disposed;
+
+    private BufferedVideoFrame(IMemoryOwner<byte> owner, int length)
+    {
+        memoryOwner = owner;
+        Length = length;
+    }
+
+    public Memory<byte> Memory => memoryOwner.Memory.Slice(0, Length);
+
+    public Span<byte> Span => memoryOwner.Memory.Span.Slice(0, Length);
+
+    public int Length { get; }
+
+    public int Width { get; private set; }
+
+    public int Height { get; private set; }
+
+    public int Stride { get; private set; }
+
+    public DateTime TimestampUtc { get; private set; }
+
+    public static BufferedVideoFrame Rent(int byteLength)
+    {
+        var owner = MemoryPool<byte>.Shared.Rent(byteLength);
+        return new BufferedVideoFrame(owner, byteLength);
+    }
+
+    public void Populate(int width, int height, int stride, DateTime timestampUtc)
+    {
+        Width = width;
+        Height = height;
+        Stride = stride;
+        TimestampUtc = timestampUtc;
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        memoryOwner.Dispose();
+    }
+}

--- a/Video/FramePump.cs
+++ b/Video/FramePump.cs
@@ -1,0 +1,100 @@
+using Serilog;
+using System.Threading;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public sealed class FramePump : IDisposable
+{
+    private readonly Func<ValueTask> invalidateCallback;
+    private readonly TimeSpan interval;
+    private readonly TimeSpan watchdogInterval;
+    private readonly CancellationTokenSource cts = new();
+    private readonly ILogger logger;
+    private Task? loopTask;
+    private long lastPaintTicks;
+
+    public FramePump(Func<ValueTask> invalidateCallback, TimeSpan interval, ILogger logger, TimeSpan? watchdogInterval = null)
+    {
+        this.invalidateCallback = invalidateCallback ?? throw new ArgumentNullException(nameof(invalidateCallback));
+        this.interval = interval;
+        this.logger = logger;
+        this.watchdogInterval = watchdogInterval ?? TimeSpan.FromSeconds(1);
+    }
+
+    public void Start()
+    {
+        loopTask = Task.Run(RunAsync);
+    }
+
+    public void NotifyPaint(DateTime timestampUtc)
+    {
+        Interlocked.Exchange(ref lastPaintTicks, timestampUtc.Ticks);
+    }
+
+    private async Task RunAsync()
+    {
+        var timer = new PeriodicTimer(interval);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(cts.Token).ConfigureAwait(false))
+            {
+                await PumpOnceAsync().ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // expected on shutdown
+        }
+        finally
+        {
+            timer.Dispose();
+        }
+    }
+
+    private async ValueTask PumpOnceAsync()
+    {
+        try
+        {
+            await invalidateCallback().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.Warning(ex, "Frame pump invalidate failed");
+        }
+
+        var lastPaint = new DateTime(Interlocked.Read(ref lastPaintTicks), DateTimeKind.Utc);
+        if (lastPaint == DateTime.MinValue)
+        {
+            return;
+        }
+
+        if (DateTime.UtcNow - lastPaint > watchdogInterval)
+        {
+            try
+            {
+                await invalidateCallback().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                logger.Warning(ex, "Frame pump watchdog invalidate failed");
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        cts.Cancel();
+        try
+        {
+            loopTask?.Wait();
+        }
+        catch (AggregateException ex) when (ex.InnerException is OperationCanceledException)
+        {
+            // ignore
+        }
+        finally
+        {
+            cts.Dispose();
+        }
+    }
+}

--- a/Video/FrameRate.cs
+++ b/Video/FrameRate.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Globalization;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public readonly struct FrameRate
+{
+    private static readonly (double fps, int n, int d)[] KnownBroadcastRates =
+    {
+        (23.976, 24000, 1001),
+        (24.0, 24, 1),
+        (25.0, 25, 1),
+        (29.97, 30000, 1001),
+        (30.0, 30, 1),
+        (50.0, 50, 1),
+        (59.94, 60000, 1001),
+        (60.0, 60, 1),
+        (120.0, 120, 1)
+    };
+
+    public FrameRate(double hertz, int numerator, int denominator)
+    {
+        if (hertz <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(hertz));
+        }
+
+        if (numerator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(numerator));
+        }
+
+        if (denominator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(denominator));
+        }
+
+        Hertz = hertz;
+        Numerator = numerator;
+        Denominator = denominator;
+    }
+
+    public double Hertz { get; }
+
+    public int Numerator { get; }
+
+    public int Denominator { get; }
+
+    public TimeSpan FrameDuration => TimeSpan.FromSeconds(1d / Hertz);
+
+    public static FrameRate Parse(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return FromDouble(60.0);
+        }
+
+        value = value.Trim();
+
+        if (TryParseRational(value, out var numerator, out var denominator))
+        {
+            return new FrameRate((double)numerator / denominator, numerator, denominator);
+        }
+
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var fps) && fps > 0)
+        {
+            return FromDouble(fps);
+        }
+
+        throw new FormatException($"Unable to parse frame rate '{value}'.");
+    }
+
+    public static FrameRate FromDouble(double fps)
+    {
+        if (fps <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(fps));
+        }
+
+        foreach (var (knownFps, knownN, knownD) in KnownBroadcastRates)
+        {
+            if (Math.Abs(knownFps - fps) < 0.005)
+            {
+                return new FrameRate(knownFps, knownN, knownD);
+            }
+        }
+
+        if (Math.Abs(fps % 1) < 0.0001)
+        {
+            return new FrameRate(fps, (int)Math.Round(fps), 1);
+        }
+
+        var (n, d) = ApproximateRational(fps, 1001);
+        return new FrameRate((double)n / d, n, d);
+    }
+
+    private static bool TryParseRational(string value, out int numerator, out int denominator)
+    {
+        numerator = 0;
+        denominator = 0;
+
+        var separatorIndex = value.IndexOfAny(new[] { '/', ':' });
+        if (separatorIndex <= 0 || separatorIndex >= value.Length - 1)
+        {
+            return false;
+        }
+
+        var numeratorText = value[..separatorIndex];
+        var denominatorText = value[(separatorIndex + 1)..];
+
+        if (!int.TryParse(numeratorText, NumberStyles.Integer, CultureInfo.InvariantCulture, out numerator))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(denominatorText, NumberStyles.Integer, CultureInfo.InvariantCulture, out denominator))
+        {
+            return false;
+        }
+
+        return numerator > 0 && denominator > 0;
+    }
+
+    private static (int numerator, int denominator) ApproximateRational(double value, int maxDenominator)
+    {
+        var fraction = ContinuedFraction(value, maxDenominator);
+        return (fraction.numerator, fraction.denominator);
+    }
+
+    private static (int numerator, int denominator) ContinuedFraction(double value, int maxDenominator)
+    {
+        var h1 = 1;
+        var h2 = 0;
+        var k1 = 0;
+        var k2 = 1;
+        var b = value;
+
+        while (true)
+        {
+            var a = (int)Math.Floor(b);
+            var h = checked(a * h1 + h2);
+            var k = checked(a * k1 + k2);
+
+            if (k > maxDenominator)
+            {
+                return (h1, k1);
+            }
+
+            if (Math.Abs(value - (double)h / k) < 1e-9)
+            {
+                return (h, k);
+            }
+
+            h2 = h1;
+            h1 = h;
+            k2 = k1;
+            k1 = k;
+
+            var fractional = b - a;
+            if (fractional == 0)
+            {
+                return (h, k);
+            }
+
+            b = 1.0 / fractional;
+        }
+    }
+}

--- a/Video/FrameRingBuffer.cs
+++ b/Video/FrameRingBuffer.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public sealed class FrameRingBuffer
+{
+    private readonly Queue<BufferedVideoFrame> queue;
+    private readonly object sync = new();
+    private readonly int capacity;
+    private long droppedFrames;
+
+    public FrameRingBuffer(int capacity)
+    {
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity));
+        }
+
+        this.capacity = capacity;
+        queue = new Queue<BufferedVideoFrame>(capacity);
+    }
+
+    public int Count
+    {
+        get
+        {
+            lock (sync)
+            {
+                return queue.Count;
+            }
+        }
+    }
+
+    public long DroppedFrames => Interlocked.Read(ref droppedFrames);
+
+    public void Enqueue(BufferedVideoFrame frame)
+    {
+        BufferedVideoFrame? dropped = null;
+
+        lock (sync)
+        {
+            if (queue.Count >= capacity)
+            {
+                dropped = queue.Dequeue();
+                Interlocked.Increment(ref droppedFrames);
+            }
+
+            queue.Enqueue(frame);
+        }
+
+        dropped?.Dispose();
+    }
+
+    public BufferedVideoFrame? TakeLatest()
+    {
+        lock (sync)
+        {
+            if (queue.Count == 0)
+            {
+                return null;
+            }
+
+            var latest = queue.Dequeue();
+            while (queue.Count > 0)
+            {
+                var stale = latest;
+                latest = queue.Dequeue();
+                stale.Dispose();
+            }
+
+            return latest;
+        }
+    }
+
+    public void Clear()
+    {
+        lock (sync)
+        {
+            while (queue.Count > 0)
+            {
+                queue.Dequeue().Dispose();
+            }
+        }
+    }
+}

--- a/Video/FrameTimeAverager.cs
+++ b/Video/FrameTimeAverager.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Threading;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public sealed class FrameTimeAverager
+{
+    private readonly double[] durations;
+    private int index;
+    private int count;
+    private long lastTimestampTicks;
+    private readonly object sync = new();
+
+    public FrameTimeAverager(int sampleCount = 120)
+    {
+        if (sampleCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleCount));
+        }
+
+        durations = new double[sampleCount];
+    }
+
+    public void AddSample(DateTime timestampUtc)
+    {
+        var previousTicks = Interlocked.Exchange(ref lastTimestampTicks, timestampUtc.Ticks);
+        if (previousTicks == 0)
+        {
+            return;
+        }
+
+        var deltaSeconds = new TimeSpan(timestampUtc.Ticks - previousTicks).TotalSeconds;
+        if (deltaSeconds <= 0)
+        {
+            return;
+        }
+
+        lock (sync)
+        {
+            durations[index] = deltaSeconds;
+            index = (index + 1) % durations.Length;
+            if (count < durations.Length)
+            {
+                count++;
+            }
+        }
+    }
+
+    public double GetAverageFps()
+    {
+        lock (sync)
+        {
+            if (count == 0)
+            {
+                return 0;
+            }
+
+            var sum = 0d;
+            for (var i = 0; i < count; i++)
+            {
+                sum += durations[i];
+            }
+
+            var averageSeconds = sum / count;
+            return averageSeconds > 0 ? 1d / averageSeconds : 0;
+        }
+    }
+
+    public void Reset()
+    {
+        lock (sync)
+        {
+            Array.Clear(durations);
+            index = 0;
+            count = 0;
+            Interlocked.Exchange(ref lastTimestampTicks, 0);
+        }
+    }
+}

--- a/Video/NdiVideoPipeline.cs
+++ b/Video/NdiVideoPipeline.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using CefSharp;
+using NewTek;
+using NewTek.NDI;
+using Serilog;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public sealed class NdiVideoPipeline : IDisposable
+{
+    private readonly nint ndiSender;
+    private readonly FrameRate frameRate;
+    private readonly ILogger logger;
+    private readonly FrameTimeAverager frameTimeAverager = new();
+    private readonly FrameRingBuffer? frameBuffer;
+    private readonly CancellationTokenSource? pacerCts;
+    private readonly Task? pacerTask;
+    private readonly TimeSpan framePeriod;
+    private readonly Timer metricsTimer;
+    private BufferedVideoFrame? lastFrame;
+    private long repeatedFrames;
+    private readonly object sendSync = new();
+    private readonly bool isBuffered;
+
+    public NdiVideoPipeline(nint ndiSender, FrameRate frameRate, int bufferDepth, ILogger logger)
+    {
+        this.ndiSender = ndiSender;
+        this.frameRate = frameRate;
+        this.logger = logger.ForContext<NdiVideoPipeline>();
+        framePeriod = frameRate.FrameDuration;
+        isBuffered = bufferDepth > 0;
+
+        if (bufferDepth > 0)
+        {
+            frameBuffer = new FrameRingBuffer(bufferDepth);
+            pacerCts = new CancellationTokenSource();
+            pacerTask = Task.Run(() => PaceAsync(pacerCts.Token));
+        }
+
+        metricsTimer = new Timer(LogMetrics, null, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10));
+    }
+
+    public bool IsBuffered => isBuffered;
+
+    public long DroppedFrames => frameBuffer?.DroppedFrames ?? 0;
+
+    public long RepeatedFrames => Interlocked.Read(ref repeatedFrames);
+
+    public void HandleFrame(OnPaintEventArgs paintArgs, DateTime timestampUtc)
+    {
+        frameTimeAverager.AddSample(timestampUtc);
+
+        if (!isBuffered)
+        {
+            SendDirect(paintArgs, timestampUtc);
+            return;
+        }
+
+        var stride = paintArgs.Width * 4;
+        var frame = BufferedVideoFrame.Rent(stride * paintArgs.Height);
+        frame.Populate(paintArgs.Width, paintArgs.Height, stride, timestampUtc);
+
+        unsafe
+        {
+            using var pin = frame.Memory.Pin();
+            Buffer.MemoryCopy((void*)paintArgs.BufferHandle, pin.Pointer, frame.Length, frame.Length);
+        }
+
+        frameBuffer!.Enqueue(frame);
+    }
+
+    private void SendDirect(OnPaintEventArgs paintArgs, DateTime timestampUtc)
+    {
+        if (ndiSender == nint.Zero)
+        {
+            return;
+        }
+
+        var videoFrame = new NDIlib.video_frame_v2_t
+        {
+            FourCC = NDIlib.FourCC_type_e.FourCC_type_BGRA,
+            frame_rate_N = frameRate.Numerator,
+            frame_rate_D = frameRate.Denominator,
+            frame_format_type = NDIlib.frame_format_type_e.frame_format_type_progressive,
+            line_stride_in_bytes = paintArgs.Width * 4,
+            picture_aspect_ratio = (float)paintArgs.Width / paintArgs.Height,
+            p_data = paintArgs.BufferHandle,
+            timecode = NDIlib.send_timecode_synthesize,
+            xres = paintArgs.Width,
+            yres = paintArgs.Height
+        };
+
+        lock (sendSync)
+        {
+            NDIlib.send_send_video_v2(ndiSender, ref videoFrame);
+        }
+    }
+
+    private async Task PaceAsync(CancellationToken cancellationToken)
+    {
+        var timer = new PeriodicTimer(framePeriod);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false))
+            {
+                BufferedVideoFrame? frame = null;
+
+                try
+                {
+                    frame = frameBuffer!.TakeLatest();
+                    if (frame is null)
+                    {
+                        if (lastFrame is not null)
+                        {
+                            Interlocked.Increment(ref repeatedFrames);
+                            await SendBufferedAsync(lastFrame, isRepeat: true).ConfigureAwait(false);
+                        }
+
+                        continue;
+                    }
+
+                    lastFrame?.Dispose();
+                    lastFrame = frame;
+                    await SendBufferedAsync(frame, isRepeat: false).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    logger.Warning(ex, "Buffered pacing tick failed");
+                    frame?.Dispose();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // expected
+        }
+        finally
+        {
+            timer.Dispose();
+        }
+    }
+
+    private async ValueTask SendBufferedAsync(BufferedVideoFrame frame, bool isRepeat)
+    {
+        if (ndiSender == nint.Zero)
+        {
+            return;
+        }
+
+        unsafe
+        {
+            using var pin = frame.Memory.Pin();
+            var videoFrame = new NDIlib.video_frame_v2_t
+            {
+                FourCC = NDIlib.FourCC_type_e.FourCC_type_BGRA,
+                frame_rate_N = frameRate.Numerator,
+                frame_rate_D = frameRate.Denominator,
+                frame_format_type = NDIlib.frame_format_type_e.frame_format_type_progressive,
+                line_stride_in_bytes = frame.Stride,
+                picture_aspect_ratio = (float)frame.Width / frame.Height,
+                p_data = (nint)pin.Pointer,
+                timecode = NDIlib.send_timecode_synthesize,
+                xres = frame.Width,
+                yres = frame.Height
+            };
+
+            lock (sendSync)
+            {
+                NDIlib.send_send_video_v2(ndiSender, ref videoFrame);
+            }
+        }
+
+        if (!isRepeat)
+        {
+            await Task.Yield();
+        }
+    }
+
+    private void LogMetrics(object? state)
+    {
+        var measuredFps = frameTimeAverager.GetAverageFps();
+        var dropped = DroppedFrames;
+        var repeats = RepeatedFrames;
+
+        logger.Information("NDI pacing metrics: target={TargetFps:F3}fps measured={MeasuredFps:F3}fps buffered={Buffered} dropped={Dropped} repeated={Repeated}", frameRate.Hertz, measuredFps, isBuffered, dropped, repeats);
+
+        TrySendMetadata(measuredFps, dropped, repeats);
+    }
+
+    private void TrySendMetadata(double measuredFps, long dropped, long repeated)
+    {
+        if (ndiSender == nint.Zero)
+        {
+            return;
+        }
+
+        var metadataXml = $"<ndi_frame_metrics target_fps=\"{frameRate.Hertz:F3}\" measured_fps=\"{measuredFps:F3}\" buffered=\"{isBuffered}\" dropped=\"{dropped}\" repeated=\"{repeated}\" />\0";
+        var ptr = UTF.StringToUtf8(metadataXml);
+        try
+        {
+            var metadataFrame = new NDIlib.metadata_frame_t
+            {
+                p_data = ptr
+            };
+
+            NDIlib.send_send_metadata(ndiSender, ref metadataFrame);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(ptr);
+        }
+    }
+
+    public void Dispose()
+    {
+        metricsTimer.Dispose();
+
+        if (isBuffered)
+        {
+            pacerCts!.Cancel();
+            try
+            {
+                pacerTask?.Wait();
+            }
+            catch (AggregateException ex) when (ex.InnerException is OperationCanceledException)
+            {
+                // ignore
+            }
+
+            pacerCts.Dispose();
+            frameBuffer!.Clear();
+            lastFrame?.Dispose();
+            lastFrame = null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a frame pump and NdiVideoPipeline that support zero-copy and buffered pacing with telemetry metadata
- expose new CLI options for frame rate, buffering, windowless refresh rate, and update documentation/agents guidance
- create a test project covering ring buffer, frame-rate parsing, and moving-average cadence calculations

## Testing
- dotnet test *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da5ca203c88329b42242d6648f4773