### PR TITLE
Implement paced NDI pipeline with buffering and tests

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Tractus.HtmlToNdi.Tests")]

--- a/README.md
+++ b/README.md
@@ -15,10 +15,17 @@ If the web page you are loading has a transparent background, NDI will honor tha
 Parameter|Description
 ----|---
 `--ndiname="NDI Source Name"`|The source name this browser instance will send. Defaults to "`HTML5`".
-`--width=1920`|The width of the browser source. Defaults to `1920`.
-`--width=1080`|The height of the browser source. Defaults to `1080`.
+`--w=1920`|The width of the browser source. Defaults to `1920`.
+`--h=1080`|The height of the browser source. Defaults to `1080`.
 `--port=9999`|The port the HTTP server will listen on. Defaults to `9999`.
 `--url="https://www.tractus.ca"`|The startup webpage. Defaults to `https://testpattern.tractusevents.com/`.
+`--fps=59.94`|Target NDI frame rate. Accepts integer, decimal or rational values (e.g. `60000/1001`). Defaults to `60`.
+`--buffer-depth=3`|Enable the paced output buffer with the specified frame capacity. Set to `0` (default) to run zero-copy.
+`--enable-output-buffer`|Shortcut to turn on paced buffering with the default depth of 3 frames.
+`--telemetry-interval=10`|Seconds between video pipeline telemetry log entries. Defaults to 10 seconds.
+`--windowless-frame-rate=60`|Overrides CEF's internal repaint cadence. Defaults to the nearest integer of `--fps`.
+`--disable-gpu-vsync`|Disables Chromium's GPU vsync throttling.
+`--disable-frame-rate-limit`|Disables Chromium's frame rate limiter.
 
 #### Example Launch
 
@@ -35,7 +42,7 @@ Route|Method|Description|Example
 - Frames are sent to NDI in RGBA format. Some machines may experience a slight performance penalty.
 - H.264 and any other non-free codecs are not available for video playback since this uses Chromium. Sites like YouTube likely won't work.
 - Audio data received from the browser is passed to NDI directly.
-- NDI frame rate is set to 60 frames per second. The internal max render frame rate is set to be capped at 60 frames per second.
+- NDI frame rate defaults to 60 fps but can be overridden with `--fps`. Chromium's internal repaint cadence can be adjusted with `--windowless-frame-rate`.
 
 ## More Tools
 

--- a/Tests/Tractus.HtmlToNdi.Tests/FrameRateTests.cs
+++ b/Tests/Tractus.HtmlToNdi.Tests/FrameRateTests.cs
@@ -1,0 +1,31 @@
+using Tractus.HtmlToNdi.Video;
+using Xunit;
+
+namespace Tractus.HtmlToNdi.Tests;
+
+public class FrameRateTests
+{
+    [Theory]
+    [InlineData("59.94", 60000, 1001)]
+    [InlineData("29.97", 30000, 1001)]
+    [InlineData("50", 50, 1)]
+    [InlineData("24", 24, 1)]
+    [InlineData("60000/1001", 60000, 1001)]
+    [InlineData("30000:1001", 30000, 1001)]
+    public void ParseRecognisesBroadcastRates(string input, int expectedNumerator, int expectedDenominator)
+    {
+        var rate = FrameRate.Parse(input);
+
+        Assert.Equal(expectedNumerator, rate.Numerator);
+        Assert.Equal(expectedDenominator, rate.Denominator);
+    }
+
+    [Fact]
+    public void FromDoubleProducesReasonableFraction()
+    {
+        var rate = FrameRate.FromDouble(47.952);
+
+        Assert.True(Math.Abs(rate.Value - 47.952) < 0.0005);
+        Assert.True(rate.Denominator <= 1000);
+    }
+}

--- a/Tests/Tractus.HtmlToNdi.Tests/FrameRingBufferTests.cs
+++ b/Tests/Tractus.HtmlToNdi.Tests/FrameRingBufferTests.cs
@@ -1,0 +1,61 @@
+using Tractus.HtmlToNdi.Video;
+using Xunit;
+
+namespace Tractus.HtmlToNdi.Tests;
+
+public class FrameRingBufferTests
+{
+    private sealed class DisposableStub : IDisposable
+    {
+        public bool Disposed { get; private set; }
+
+        public void Dispose()
+        {
+            Disposed = true;
+        }
+    }
+
+    [Fact]
+    public void DropsOldestWhenCapacityReached()
+    {
+        var buffer = new FrameRingBuffer<DisposableStub>(2);
+        var first = new DisposableStub();
+        var second = new DisposableStub();
+        var third = new DisposableStub();
+
+        buffer.Enqueue(first, out var dropped1);
+        Assert.Null(dropped1);
+
+        buffer.Enqueue(second, out var dropped2);
+        Assert.Null(dropped2);
+
+        buffer.Enqueue(third, out var dropped3);
+        Assert.Same(first, dropped3);
+        dropped3?.Dispose();
+        Assert.True(first.Disposed);
+        Assert.Equal(1, buffer.DroppedFromOverflow);
+
+        var latest = buffer.DequeueLatest();
+        Assert.Same(third, latest);
+        Assert.Equal(0, buffer.DroppedAsStale);
+    }
+
+    [Fact]
+    public void DequeueLatestDropsStaleFrames()
+    {
+        var buffer = new FrameRingBuffer<DisposableStub>(3);
+        var first = new DisposableStub();
+        var second = new DisposableStub();
+        var third = new DisposableStub();
+
+        buffer.Enqueue(first, out _);
+        buffer.Enqueue(second, out _);
+        buffer.Enqueue(third, out _);
+
+        var latest = buffer.DequeueLatest();
+        Assert.Same(third, latest);
+        Assert.True(first.Disposed);
+        Assert.True(second.Disposed);
+        Assert.Equal(2, buffer.DroppedAsStale);
+    }
+}

--- a/Tests/Tractus.HtmlToNdi.Tests/NdiVideoPipelineTests.cs
+++ b/Tests/Tractus.HtmlToNdi.Tests/NdiVideoPipelineTests.cs
@@ -1,0 +1,110 @@
+using System.Runtime.InteropServices;
+using Serilog;
+using Serilog.Core;
+using Tractus.HtmlToNdi.Video;
+using Xunit;
+using NewTek.NDI;
+
+namespace Tractus.HtmlToNdi.Tests;
+
+public class NdiVideoPipelineTests
+{
+    private sealed class CollectingSender : INdiVideoSender
+    {
+        private readonly object gate = new();
+        private readonly List<NDIlib.video_frame_v2_t> frames = new();
+
+        public IReadOnlyList<NDIlib.video_frame_v2_t> Frames
+        {
+            get
+            {
+                lock (gate)
+                {
+                    return frames.ToList();
+                }
+            }
+        }
+
+        public void Send(ref NDIlib.video_frame_v2_t frame)
+        {
+            lock (gate)
+            {
+                frames.Add(frame);
+            }
+        }
+    }
+
+    private static ILogger CreateNullLogger() => new LoggerConfiguration().WriteTo.Sink(new NullSink()).CreateLogger();
+
+    [Fact]
+    public void DirectModeSendsImmediately()
+    {
+        var sender = new CollectingSender();
+        var options = new NdiVideoPipelineOptions
+        {
+            EnableBuffering = false,
+            TelemetryInterval = TimeSpan.FromDays(1)
+        };
+
+        var pipeline = new NdiVideoPipeline(sender, new FrameRate(60, 1), options, CreateNullLogger());
+
+        var size = 4 * 2 * 2;
+        var buffer = Marshal.AllocHGlobal(size);
+        try
+        {
+            var frame = new CapturedFrame(buffer, 2, 2, 8);
+            pipeline.HandleFrame(frame);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+            pipeline.Dispose();
+        }
+
+        var frames = sender.Frames;
+        Assert.Single(frames);
+        Assert.Equal(60, frames[0].frame_rate_N);
+        Assert.Equal(1, frames[0].frame_rate_D);
+    }
+
+    [Fact]
+    public async Task BufferedModeRepeatsLastFrameWhenIdle()
+    {
+        var sender = new CollectingSender();
+        var options = new NdiVideoPipelineOptions
+        {
+            EnableBuffering = true,
+            BufferDepth = 2,
+            TelemetryInterval = TimeSpan.FromDays(1)
+        };
+
+        var pipeline = new NdiVideoPipeline(sender, new FrameRate(30, 1), options, CreateNullLogger());
+        pipeline.Start();
+
+        var size = 4 * 2 * 2;
+        var buffer = Marshal.AllocHGlobal(size);
+        try
+        {
+            var frame = new CapturedFrame(buffer, 2, 2, 8);
+            pipeline.HandleFrame(frame);
+
+            await Task.Delay(200);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+            pipeline.Dispose();
+        }
+
+        var frames = sender.Frames;
+        Assert.True(frames.Count >= 2, "Expected at least one repeat frame");
+        Assert.Equal(frames[0].p_data, frames[1].p_data);
+    }
+}
+
+internal sealed class NullSink : ILogEventSink
+{
+    public void Emit(Serilog.Events.LogEvent logEvent)
+    {
+    }
+}

--- a/Tests/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
+++ b/Tests/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Tractus.HtmlToNdi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tractus.HtmlToNdi.sln
+++ b/Tractus.HtmlToNdi.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.11.35303.130
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tractus.HtmlToNdi", "Tractus.HtmlToNdi.csproj", "{6B6C038D-3984-455A-95CA-A9079B3FC4E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tractus.HtmlToNdi.Tests", "Tests\Tractus.HtmlToNdi.Tests\Tractus.HtmlToNdi.Tests.csproj", "{D0EAC4A5-9F69-4DF1-B136-DCF7A5E46E89}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,9 +20,17 @@ Global
 		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|x64.ActiveCfg = Debug|x64
 		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Debug|x64.Build.0 = Debug|x64
 		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.ActiveCfg = Release|x64
-		{6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.Build.0 = Release|x64
+                {6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|Any CPU.Build.0 = Release|Any CPU
+                {6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.ActiveCfg = Release|x64
+                {6B6C038D-3984-455A-95CA-A9079B3FC4E2}.Release|x64.Build.0 = Release|x64
+                {D0EAC4A5-9F69-4DF1-B136-DCF7A5E46E89}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {D0EAC4A5-9F69-4DF1-B136-DCF7A5E46E89}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {D0EAC4A5-9F69-4DF1-B136-DCF7A5E46E89}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {D0EAC4A5-9F69-4DF1-B136-DCF7A5E46E89}.Debug|x64.Build.0 = Debug|Any CPU
+                {D0EAC4A5-9F69-4DF1-B136-DCF7A5E46E89}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {D0EAC4A5-9F69-4DF1-B136-DCF7A5E46E89}.Release|Any CPU.Build.0 = Release|Any CPU
+                {D0EAC4A5-9F69-4DF1-B136-DCF7A5E46E89}.Release|x64.ActiveCfg = Release|Any CPU
+                {D0EAC4A5-9F69-4DF1-B136-DCF7A5E46E89}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Video/CapturedFrame.cs
+++ b/Video/CapturedFrame.cs
@@ -1,0 +1,22 @@
+namespace Tractus.HtmlToNdi.Video;
+
+internal readonly struct CapturedFrame
+{
+    public CapturedFrame(IntPtr buffer, int width, int height, int stride)
+    {
+        Buffer = buffer;
+        Width = width;
+        Height = height;
+        Stride = stride;
+    }
+
+    public IntPtr Buffer { get; }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public int Stride { get; }
+
+    public int SizeInBytes => Height * Stride;
+}

--- a/Video/FramePump.cs
+++ b/Video/FramePump.cs
@@ -1,0 +1,115 @@
+using CefSharp.OffScreen;
+using Serilog;
+
+namespace Tractus.HtmlToNdi.Video;
+
+internal sealed class FramePump : IDisposable
+{
+    private readonly ChromiumWebBrowser browser;
+    private readonly TimeSpan interval;
+    private readonly TimeSpan watchdogInterval;
+    private readonly CancellationTokenSource cancellation = new();
+    private readonly ILogger logger;
+    private Task? pumpTask;
+    private Task? watchdogTask;
+    private DateTime lastPaint = DateTime.UtcNow;
+
+    public FramePump(ChromiumWebBrowser browser, TimeSpan interval, TimeSpan? watchdogInterval, ILogger logger)
+    {
+        this.browser = browser ?? throw new ArgumentNullException(nameof(browser));
+        this.interval = interval;
+        this.watchdogInterval = watchdogInterval ?? TimeSpan.FromSeconds(1);
+        this.logger = logger;
+    }
+
+    public void Start()
+    {
+        if (pumpTask is not null)
+        {
+            return;
+        }
+
+        pumpTask = Task.Run(async () => await RunPumpAsync(cancellation.Token));
+        watchdogTask = Task.Run(async () => await RunWatchdogAsync(cancellation.Token));
+    }
+
+    public void NotifyPaint() => lastPaint = DateTime.UtcNow;
+
+    private async Task RunPumpAsync(CancellationToken token)
+    {
+        var timer = new PeriodicTimer(interval);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(token))
+            {
+                await InvalidateAsync();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // expected
+        }
+        finally
+        {
+            timer.Dispose();
+        }
+    }
+
+    private async Task RunWatchdogAsync(CancellationToken token)
+    {
+        try
+        {
+            while (!token.IsCancellationRequested)
+            {
+                await Task.Delay(watchdogInterval, token);
+                if (DateTime.UtcNow - lastPaint > watchdogInterval)
+                {
+                    logger.Debug("FramePump watchdog: re-invalidate Chromium after {Seconds}s", watchdogInterval.TotalSeconds);
+                    await InvalidateAsync();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // shutting down
+        }
+    }
+
+    private async Task InvalidateAsync()
+    {
+        try
+        {
+            var host = browser.GetBrowserHost();
+            if (host is null)
+            {
+                return;
+            }
+
+            await Cef.UIThreadTaskFactory.StartNew(() =>
+            {
+                host.Invalidate(CefSharp.PaintElementType.View);
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.Warning(ex, "FramePump failed to invalidate Chromium");
+        }
+    }
+
+    public void Dispose()
+    {
+        cancellation.Cancel();
+        try
+        {
+            pumpTask?.Wait();
+            watchdogTask?.Wait();
+        }
+        catch (Exception ex) when (ex is AggregateException or OperationCanceledException)
+        {
+        }
+
+        pumpTask = null;
+        watchdogTask = null;
+        cancellation.Dispose();
+    }
+}

--- a/Video/FrameRate.cs
+++ b/Video/FrameRate.cs
@@ -1,0 +1,162 @@
+using System.Globalization;
+
+namespace Tractus.HtmlToNdi.Video;
+
+public readonly struct FrameRate
+{
+    private static readonly (double fps, int numerator, int denominator)[] KnownRates =
+    {
+        (23.976, 24000, 1001),
+        (24.0, 24, 1),
+        (25.0, 25, 1),
+        (29.97, 30000, 1001),
+        (30.0, 30, 1),
+        (50.0, 50, 1),
+        (59.94, 60000, 1001),
+        (60.0, 60, 1),
+        (119.88, 120000, 1001),
+        (120.0, 120, 1)
+    };
+
+    public FrameRate(int numerator, int denominator)
+    {
+        if (denominator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(denominator));
+        }
+
+        if (numerator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(numerator));
+        }
+
+        Numerator = numerator;
+        Denominator = denominator;
+    }
+
+    public int Numerator { get; }
+
+    public int Denominator { get; }
+
+    public double Value => Numerator / (double)Denominator;
+
+    public TimeSpan FrameDuration => TimeSpan.FromSeconds(1.0 / Value);
+
+    public static FrameRate Parse(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return new FrameRate(60, 1);
+        }
+
+        text = text.Trim();
+
+        if (TryParseFraction(text, out var fraction))
+        {
+            return fraction;
+        }
+
+        if (double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
+        {
+            return FromDouble(value);
+        }
+
+        throw new FormatException($"Unable to parse frame rate from '{text}'.");
+    }
+
+    public static FrameRate FromDouble(double fps)
+    {
+        if (fps <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(fps));
+        }
+
+        foreach (var (knownFps, numerator, denominator) in KnownRates)
+        {
+            if (Math.Abs(knownFps - fps) < 0.0005)
+            {
+                return new FrameRate(numerator, denominator);
+            }
+        }
+
+        if (Math.Abs(fps - Math.Round(fps)) < 0.000001)
+        {
+            return new FrameRate((int)Math.Round(fps), 1);
+        }
+
+        // Convert to a reasonable fraction using continued fractions up to denominator 1000.
+        const int maxDenominator = 1000;
+        var fraction = ToFraction(fps, maxDenominator);
+        return new FrameRate(fraction.numerator, fraction.denominator);
+    }
+
+    private static bool TryParseFraction(string text, out FrameRate rate)
+    {
+        rate = default;
+        var separators = new[] { '/', ':' };
+        foreach (var separator in separators)
+        {
+            var parts = text.Split(separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length == 2 &&
+                int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var numerator) &&
+                int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var denominator) &&
+                numerator > 0 && denominator > 0)
+            {
+                rate = new FrameRate(numerator, denominator);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static (int numerator, int denominator) ToFraction(double value, int maxDenominator)
+    {
+        var fraction = ContinuedFraction(value, maxDenominator);
+        return (fraction.numerator, fraction.denominator);
+    }
+
+    private static (int numerator, int denominator) ContinuedFraction(double value, int maxDenominator)
+    {
+        int previousNumerator = 0;
+        int numerator = 1;
+        int previousDenominator = 1;
+        int denominator = 0;
+
+        var fraction = value;
+
+        while (true)
+        {
+            var integralPart = (int)Math.Floor(fraction);
+            var tempNumerator = integralPart * numerator + previousNumerator;
+            var tempDenominator = integralPart * denominator + previousDenominator;
+
+            if (tempDenominator > maxDenominator)
+            {
+                break;
+            }
+
+            previousNumerator = numerator;
+            numerator = tempNumerator;
+            previousDenominator = denominator;
+            denominator = tempDenominator;
+
+            var delta = fraction - integralPart;
+            if (Math.Abs(delta) < 1e-9)
+            {
+                break;
+            }
+
+            fraction = 1.0 / delta;
+        }
+
+        if (denominator == 0)
+        {
+            return ((int)Math.Round(value), 1);
+        }
+
+        return (numerator, denominator);
+    }
+
+    public override string ToString() => $"{Numerator}/{Denominator}";
+}

--- a/Video/FrameRingBuffer.cs
+++ b/Video/FrameRingBuffer.cs
@@ -1,0 +1,82 @@
+namespace Tractus.HtmlToNdi.Video;
+
+internal sealed class FrameRingBuffer<T>
+    where T : class, IDisposable
+{
+    private readonly int capacity;
+    private readonly Queue<T> frames;
+
+    public FrameRingBuffer(int capacity)
+    {
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity));
+        }
+
+        this.capacity = capacity;
+        frames = new Queue<T>(capacity);
+    }
+
+    public int Capacity => capacity;
+
+    public int Count
+    {
+        get
+        {
+            lock (frames)
+            {
+                return frames.Count;
+            }
+        }
+    }
+
+    public long DroppedFromOverflow { get; private set; }
+
+    public long DroppedAsStale { get; private set; }
+
+    public void Enqueue(T frame, out T? dropped)
+    {
+        dropped = null;
+        lock (frames)
+        {
+            if (frames.Count == capacity)
+            {
+                dropped = frames.Dequeue();
+                DroppedFromOverflow++;
+            }
+
+            frames.Enqueue(frame);
+        }
+    }
+
+    public T? DequeueLatest()
+    {
+        lock (frames)
+        {
+            if (frames.Count == 0)
+            {
+                return null;
+            }
+
+            while (frames.Count > 1)
+            {
+                var stale = frames.Dequeue();
+                stale.Dispose();
+                DroppedAsStale++;
+            }
+
+            return frames.Dequeue();
+        }
+    }
+
+    public void Clear()
+    {
+        lock (frames)
+        {
+            while (frames.Count > 0)
+            {
+                frames.Dequeue().Dispose();
+            }
+        }
+    }
+}

--- a/Video/FrameTimeAverager.cs
+++ b/Video/FrameTimeAverager.cs
@@ -1,0 +1,53 @@
+namespace Tractus.HtmlToNdi.Video;
+
+internal sealed class FrameTimeAverager
+{
+    private readonly int capacity;
+    private readonly Queue<double> samples;
+    private double sum;
+    private DateTime? lastTimestamp;
+
+    public FrameTimeAverager(int capacity = 60)
+    {
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity));
+        }
+
+        this.capacity = capacity;
+        this.samples = new Queue<double>(capacity);
+    }
+
+    public double? AddTimestamp(DateTime timestamp)
+    {
+        if (lastTimestamp.HasValue)
+        {
+            var delta = (timestamp - lastTimestamp.Value).TotalSeconds;
+            if (delta > 0)
+            {
+                if (samples.Count == capacity)
+                {
+                    sum -= samples.Dequeue();
+                }
+
+                samples.Enqueue(delta);
+                sum += delta;
+            }
+        }
+
+        lastTimestamp = timestamp;
+
+        if (samples.Count < 3)
+        {
+            return null;
+        }
+
+        var averageSeconds = sum / samples.Count;
+        if (averageSeconds <= 0)
+        {
+            return null;
+        }
+
+        return 1.0 / averageSeconds;
+    }
+}

--- a/Video/INdiVideoSender.cs
+++ b/Video/INdiVideoSender.cs
@@ -1,0 +1,28 @@
+using NewTek.NDI;
+
+namespace Tractus.HtmlToNdi.Video;
+
+internal interface INdiVideoSender
+{
+    void Send(ref NDIlib.video_frame_v2_t frame);
+}
+
+internal sealed class NativeNdiVideoSender : INdiVideoSender
+{
+    private readonly nint senderPtr;
+
+    public NativeNdiVideoSender(nint senderPtr)
+    {
+        if (senderPtr == nint.Zero)
+        {
+            throw new ArgumentException("Invalid NDI sender handle", nameof(senderPtr));
+        }
+
+        this.senderPtr = senderPtr;
+    }
+
+    public void Send(ref NDIlib.video_frame_v2_t frame)
+    {
+        NDIlib.send_send_video_v2(senderPtr, ref frame);
+    }
+}

--- a/Video/NdiVideoFrame.cs
+++ b/Video/NdiVideoFrame.cs
@@ -1,0 +1,50 @@
+using System.Runtime.InteropServices;
+
+namespace Tractus.HtmlToNdi.Video;
+
+internal sealed class NdiVideoFrame : IDisposable
+{
+    public NdiVideoFrame(int width, int height, int stride, IntPtr buffer)
+    {
+        Width = width;
+        Height = height;
+        Stride = stride;
+        Buffer = buffer;
+    }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public int Stride { get; }
+
+    public IntPtr Buffer { get; private set; }
+
+    public DateTime Timestamp { get; set; }
+
+    public static NdiVideoFrame CopyFrom(CapturedFrame frame)
+    {
+        var size = frame.SizeInBytes;
+        var buffer = Marshal.AllocHGlobal(size);
+        unsafe
+        {
+            Buffer.MemoryCopy((void*)frame.Buffer, (void*)buffer, size, size);
+        }
+
+        return new NdiVideoFrame(frame.Width, frame.Height, frame.Stride, buffer)
+        {
+            Timestamp = DateTime.UtcNow
+        };
+    }
+
+    public void Dispose()
+    {
+        if (Buffer != IntPtr.Zero)
+        {
+            Marshal.FreeHGlobal(Buffer);
+            Buffer = IntPtr.Zero;
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Video/NdiVideoPipeline.cs
+++ b/Video/NdiVideoPipeline.cs
@@ -1,0 +1,245 @@
+using NewTek.NDI;
+using Serilog;
+using System.Runtime.CompilerServices;
+
+namespace Tractus.HtmlToNdi.Video;
+
+internal sealed class NdiVideoPipeline : IDisposable
+{
+    private readonly INdiVideoSender sender;
+    private readonly FrameRate configuredFrameRate;
+    private readonly NdiVideoPipelineOptions options;
+    private readonly FrameTimeAverager timeAverager = new();
+    private readonly CancellationTokenSource cancellation = new();
+    private readonly FrameRingBuffer<NdiVideoFrame>? ringBuffer;
+    private readonly ILogger logger;
+
+    private Task? pacingTask;
+    private NdiVideoFrame? lastSentFrame;
+    private long capturedFrames;
+    private long sentFrames;
+    private long repeatedFrames;
+    private DateTime lastTelemetry = DateTime.UtcNow;
+
+    public NdiVideoPipeline(INdiVideoSender sender, FrameRate frameRate, NdiVideoPipelineOptions options, ILogger logger)
+    {
+        this.sender = sender ?? throw new ArgumentNullException(nameof(sender));
+        configuredFrameRate = frameRate;
+        this.options = options ?? throw new ArgumentNullException(nameof(options));
+        this.logger = logger;
+
+        if (options.EnableBuffering)
+        {
+            ringBuffer = new FrameRingBuffer<NdiVideoFrame>(Math.Max(1, options.BufferDepth));
+        }
+    }
+
+    public bool BufferingEnabled => options.EnableBuffering;
+
+    public FrameRate FrameRate => configuredFrameRate;
+
+    public void Start()
+    {
+        if (!BufferingEnabled || pacingTask != null)
+        {
+            return;
+        }
+
+        pacingTask = Task.Run(async () => await RunPacedLoopAsync(cancellation.Token));
+    }
+
+    public void Stop()
+    {
+        cancellation.Cancel();
+        try
+        {
+            pacingTask?.Wait();
+        }
+        catch (Exception ex) when (ex is TaskCanceledException || ex is AggregateException)
+        {
+            // ignore
+        }
+
+        pacingTask = null;
+    }
+
+    public void HandleFrame(CapturedFrame frame)
+    {
+        Interlocked.Increment(ref capturedFrames);
+
+        if (!BufferingEnabled)
+        {
+            SendDirect(frame);
+            return;
+        }
+
+        if (ringBuffer is null)
+        {
+            return;
+        }
+
+        NdiVideoFrame? dropped = null;
+        var copy = NdiVideoFrame.CopyFrom(frame);
+        ringBuffer.Enqueue(copy, out dropped);
+        dropped?.Dispose();
+        EmitTelemetryIfNeeded();
+    }
+
+    private async Task RunPacedLoopAsync(CancellationToken token)
+    {
+        var timer = new PeriodicTimer(FrameRate.FrameDuration);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(token))
+            {
+                if (token.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                NdiVideoFrame? frame = ringBuffer?.DequeueLatest();
+                if (frame is not null)
+                {
+                    SendBufferedFrame(frame);
+                    continue;
+                }
+
+                if (lastSentFrame is not null)
+                {
+                    RepeatLastFrame();
+                }
+            }
+        }
+        finally
+        {
+            timer.Dispose();
+        }
+    }
+
+    private void SendDirect(CapturedFrame frame)
+    {
+        if (frame.Buffer == IntPtr.Zero)
+        {
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        var (numerator, denominator) = ResolveFrameRate(now);
+
+        var ndiFrame = CreateVideoFrame(frame, numerator, denominator);
+        sender.Send(ref ndiFrame);
+        Interlocked.Increment(ref sentFrames);
+        EmitTelemetryIfNeeded();
+    }
+
+    private void SendBufferedFrame(NdiVideoFrame frame)
+    {
+        var (numerator, denominator) = ResolveFrameRate(frame.Timestamp);
+
+        var ndiFrame = CreateVideoFrame(frame, numerator, denominator);
+        sender.Send(ref ndiFrame);
+
+        Interlocked.Increment(ref sentFrames);
+
+        lastSentFrame?.Dispose();
+        lastSentFrame = frame;
+
+        EmitTelemetryIfNeeded();
+    }
+
+    private void RepeatLastFrame()
+    {
+        if (lastSentFrame is null)
+        {
+            return;
+        }
+
+        var ndiFrame = CreateVideoFrame(lastSentFrame, configuredFrameRate.Numerator, configuredFrameRate.Denominator);
+        sender.Send(ref ndiFrame);
+        Interlocked.Increment(ref repeatedFrames);
+        EmitTelemetryIfNeeded();
+    }
+
+    private (int numerator, int denominator) ResolveFrameRate(DateTime timestamp)
+    {
+        var measured = timeAverager.AddTimestamp(timestamp);
+        if (!measured.HasValue)
+        {
+            return (configuredFrameRate.Numerator, configuredFrameRate.Denominator);
+        }
+
+        try
+        {
+            var measuredRate = FrameRate.FromDouble(measured.Value);
+            return (measuredRate.Numerator, measuredRate.Denominator);
+        }
+        catch
+        {
+            return (configuredFrameRate.Numerator, configuredFrameRate.Denominator);
+        }
+    }
+
+    private static NDIlib.video_frame_v2_t CreateVideoFrame(NdiVideoFrame frame, int numerator, int denominator)
+    {
+        return new NDIlib.video_frame_v2_t
+        {
+            FourCC = NDIlib.FourCC_type_e.FourCC_type_BGRA,
+            frame_rate_N = numerator,
+            frame_rate_D = denominator,
+            frame_format_type = NDIlib.frame_format_type_e.frame_format_type_progressive,
+            line_stride_in_bytes = frame.Stride,
+            picture_aspect_ratio = frame.Width / (float)frame.Height,
+            p_data = frame.Buffer,
+            timecode = NDIlib.send_timecode_synthesize,
+            xres = frame.Width,
+            yres = frame.Height,
+        };
+    }
+
+    private static NDIlib.video_frame_v2_t CreateVideoFrame(CapturedFrame frame, int numerator, int denominator)
+    {
+        return new NDIlib.video_frame_v2_t
+        {
+            FourCC = NDIlib.FourCC_type_e.FourCC_type_BGRA,
+            frame_rate_N = numerator,
+            frame_rate_D = denominator,
+            frame_format_type = NDIlib.frame_format_type_e.frame_format_type_progressive,
+            line_stride_in_bytes = frame.Stride,
+            picture_aspect_ratio = frame.Width / (float)frame.Height,
+            p_data = frame.Buffer,
+            timecode = NDIlib.send_timecode_synthesize,
+            xres = frame.Width,
+            yres = frame.Height,
+        };
+    }
+
+    private void EmitTelemetryIfNeeded([CallerMemberName] string? caller = null)
+    {
+        if (DateTime.UtcNow - lastTelemetry < options.TelemetryInterval)
+        {
+            return;
+        }
+
+        lastTelemetry = DateTime.UtcNow;
+
+        var bufferStats = BufferingEnabled && ringBuffer is not null
+            ? $", buffered={ringBuffer.Count}, droppedOverflow={ringBuffer.DroppedFromOverflow}, droppedStale={ringBuffer.DroppedAsStale}"
+            : string.Empty;
+
+        logger.Information(
+            "NDI video pipeline stats: captured={Captured}, sent={Sent}, repeated={Repeated}{BufferStats} (caller={Caller})",
+            Interlocked.Read(ref capturedFrames),
+            Interlocked.Read(ref sentFrames),
+            Interlocked.Read(ref repeatedFrames),
+            bufferStats,
+            caller);
+    }
+
+    public void Dispose()
+    {
+        Stop();
+        ringBuffer?.Clear();
+        lastSentFrame?.Dispose();
+        cancellation.Dispose();
+    }
+}

--- a/Video/NdiVideoPipelineOptions.cs
+++ b/Video/NdiVideoPipelineOptions.cs
@@ -1,0 +1,10 @@
+namespace Tractus.HtmlToNdi.Video;
+
+internal sealed record NdiVideoPipelineOptions
+{
+    public bool EnableBuffering { get; init; }
+
+    public int BufferDepth { get; init; } = 3;
+
+    public TimeSpan TelemetryInterval { get; init; } = TimeSpan.FromSeconds(10);
+}


### PR DESCRIPTION
## Summary
- add a reusable video pipeline that supports direct and paced buffered delivery with frame-rate telemetry
- drive Chromium with a watchdog-backed frame pump and expose CLI switches for fps, buffering depth, telemetry and GPU throttling
- document the new workflow and add xUnit coverage for the frame-rate parser, ring buffer and pipeline pacing helpers

## Testing
- dotnet test *(fails: dotnet CLI is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da5ca203c88329b42242d6648f4773