### PR TITLE
Add Windows launcher UI for configuring runtime settings

### DIFF
--- a/Launcher/LauncherForm.cs
+++ b/Launcher/LauncherForm.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Drawing;
+using System.Globalization;
+using System.Windows.Forms;
+
+namespace Tractus.HtmlToNdi.Launcher;
+
+public class LauncherForm : Form
+{
+    private readonly TextBox _ndiNameTextBox;
+    private readonly NumericUpDown _portNumeric;
+    private readonly TextBox _urlTextBox;
+    private readonly NumericUpDown _widthNumeric;
+    private readonly NumericUpDown _heightNumeric;
+    private readonly TextBox _frameRateTextBox;
+    private readonly CheckBox _enableBufferingCheckbox;
+    private readonly NumericUpDown _bufferDepthNumeric;
+    private readonly NumericUpDown _telemetryNumeric;
+    private readonly TextBox _windowlessFrameRateTextBox;
+    private readonly CheckBox _disableGpuVsyncCheckbox;
+    private readonly CheckBox _disableFrameRateLimitCheckbox;
+
+    public LauncherSettings? SelectedSettings { get; private set; }
+
+    public LauncherForm(LauncherSettings settings)
+    {
+        Text = "HTML to NDI Launcher";
+        FormBorderStyle = FormBorderStyle.FixedDialog;
+        MaximizeBox = false;
+        MinimizeBox = false;
+        StartPosition = FormStartPosition.CenterScreen;
+        AutoSize = true;
+        AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+
+        var layout = new TableLayoutPanel
+        {
+            ColumnCount = 2,
+            Dock = DockStyle.Fill,
+            Padding = new Padding(12),
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+        };
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+
+        Controls.Add(layout);
+
+        _ndiNameTextBox = new TextBox { Text = settings.NdiName, Dock = DockStyle.Fill };
+        AddRow(layout, "NDI Source Name:", _ndiNameTextBox);
+
+        _portNumeric = new NumericUpDown
+        {
+            Minimum = 1,
+            Maximum = 65535,
+            Value = Math.Clamp(settings.Port, 1, 65535),
+            Dock = DockStyle.Fill,
+        };
+        AddRow(layout, "HTTP Port:", _portNumeric);
+
+        _urlTextBox = new TextBox { Text = settings.Url, Dock = DockStyle.Fill };
+        AddRow(layout, "Startup URL:", _urlTextBox);
+
+        _widthNumeric = new NumericUpDown
+        {
+            Minimum = 1,
+            Maximum = 10000,
+            Value = Math.Clamp(settings.Width, 1, 10000),
+            Dock = DockStyle.Fill,
+        };
+        AddRow(layout, "Width (px):", _widthNumeric);
+
+        _heightNumeric = new NumericUpDown
+        {
+            Minimum = 1,
+            Maximum = 10000,
+            Value = Math.Clamp(settings.Height, 1, 10000),
+            Dock = DockStyle.Fill,
+        };
+        AddRow(layout, "Height (px):", _heightNumeric);
+
+        _frameRateTextBox = new TextBox { Text = settings.FrameRate, Dock = DockStyle.Fill };
+        AddRow(layout, "Frame Rate (fps):", _frameRateTextBox);
+
+        _enableBufferingCheckbox = new CheckBox
+        {
+            Checked = settings.EnableOutputBuffer,
+            Text = "Enable paced output buffer",
+            AutoSize = true,
+        };
+        AddRow(layout, string.Empty, _enableBufferingCheckbox);
+
+        _bufferDepthNumeric = new NumericUpDown
+        {
+            Minimum = 1,
+            Maximum = 30,
+            Value = Math.Clamp(settings.BufferDepth, 1, 30),
+            Dock = DockStyle.Fill,
+            Enabled = settings.EnableOutputBuffer,
+        };
+        AddRow(layout, "Buffer Depth (frames):", _bufferDepthNumeric);
+
+        _telemetryNumeric = new NumericUpDown
+        {
+            Minimum = 1,
+            Maximum = 600,
+            Value = Convert.ToDecimal(Math.Clamp(settings.TelemetryIntervalSeconds, 1, 600)),
+            Dock = DockStyle.Fill,
+            DecimalPlaces = 1,
+            Increment = 0.5m,
+        };
+        AddRow(layout, "Telemetry Interval (s):", _telemetryNumeric);
+
+        _windowlessFrameRateTextBox = new TextBox
+        {
+            Text = settings.WindowlessFrameRate ?? string.Empty,
+            Dock = DockStyle.Fill,
+        };
+        AddRow(layout, "Windowless Frame Rate Override:", _windowlessFrameRateTextBox);
+
+        _disableGpuVsyncCheckbox = new CheckBox
+        {
+            Checked = settings.DisableGpuVsync,
+            Text = "Disable GPU VSync",
+            AutoSize = true,
+        };
+        AddRow(layout, string.Empty, _disableGpuVsyncCheckbox);
+
+        _disableFrameRateLimitCheckbox = new CheckBox
+        {
+            Checked = settings.DisableFrameRateLimit,
+            Text = "Disable frame rate limit",
+            AutoSize = true,
+        };
+        AddRow(layout, string.Empty, _disableFrameRateLimitCheckbox);
+
+        _enableBufferingCheckbox.CheckedChanged += (_, _) =>
+        {
+            _bufferDepthNumeric.Enabled = _enableBufferingCheckbox.Checked;
+        };
+
+        var buttonPanel = new FlowLayoutPanel
+        {
+            FlowDirection = FlowDirection.RightToLeft,
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+        };
+
+        var launchButton = new Button
+        {
+            Text = "Launch",
+            AutoSize = true,
+        };
+        launchButton.Click += (_, _) => Launch();
+
+        var cancelButton = new Button
+        {
+            Text = "Cancel",
+            AutoSize = true,
+            DialogResult = DialogResult.Cancel,
+        };
+
+        buttonPanel.Controls.Add(launchButton);
+        buttonPanel.Controls.Add(cancelButton);
+
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        var buttonsRowIndex = layout.RowCount++;
+        layout.Controls.Add(buttonPanel, 0, buttonsRowIndex);
+        layout.SetColumnSpan(buttonPanel, 2);
+
+        AcceptButton = launchButton;
+        CancelButton = cancelButton;
+    }
+
+    private static void AddRow(TableLayoutPanel layout, string labelText, Control control)
+    {
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        var rowIndex = layout.RowCount++;
+
+        if (!string.IsNullOrEmpty(labelText))
+        {
+            var label = new Label
+            {
+                Text = labelText,
+                TextAlign = ContentAlignment.MiddleLeft,
+                AutoSize = true,
+                Dock = DockStyle.Fill,
+                Margin = new Padding(0, 6, 12, 6),
+            };
+            layout.Controls.Add(label, 0, rowIndex);
+        }
+        else
+        {
+            layout.Controls.Add(new Label { AutoSize = true }, 0, rowIndex);
+        }
+
+        control.Margin = new Padding(0, 6, 0, 6);
+        layout.Controls.Add(control, 1, rowIndex);
+    }
+
+    private void Launch()
+    {
+        if (string.IsNullOrWhiteSpace(_ndiNameTextBox.Text))
+        {
+            ShowValidationError("NDI source name is required.");
+            return;
+        }
+
+        if (!Uri.TryCreate(_urlTextBox.Text.Trim(), UriKind.Absolute, out _))
+        {
+            ShowValidationError("Startup URL must be a valid absolute URI.");
+            return;
+        }
+
+        var frameRate = _frameRateTextBox.Text.Trim();
+        if (frameRate.Length == 0)
+        {
+            ShowValidationError("Frame rate is required (decimal or fraction).");
+            return;
+        }
+
+        var windowlessOverride = _windowlessFrameRateTextBox.Text.Trim();
+        if (windowlessOverride.Length > 0 && !double.TryParse(windowlessOverride, NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+        {
+            ShowValidationError("Windowless frame rate override must be a number.");
+            return;
+        }
+
+        SelectedSettings = new LauncherSettings
+        {
+            NdiName = _ndiNameTextBox.Text.Trim(),
+            Port = Convert.ToInt32(_portNumeric.Value),
+            Url = _urlTextBox.Text.Trim(),
+            Width = Convert.ToInt32(_widthNumeric.Value),
+            Height = Convert.ToInt32(_heightNumeric.Value),
+            FrameRate = frameRate,
+            EnableOutputBuffer = _enableBufferingCheckbox.Checked,
+            BufferDepth = Convert.ToInt32(_bufferDepthNumeric.Value),
+            TelemetryIntervalSeconds = decimal.ToDouble(_telemetryNumeric.Value),
+            WindowlessFrameRate = windowlessOverride.Length > 0 ? windowlessOverride : null,
+            DisableGpuVsync = _disableGpuVsyncCheckbox.Checked,
+            DisableFrameRateLimit = _disableFrameRateLimitCheckbox.Checked,
+        };
+
+        DialogResult = DialogResult.OK;
+        Close();
+    }
+
+    private void ShowValidationError(string message)
+    {
+        MessageBox.Show(this, message, "Validation error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+    }
+}

--- a/Launcher/LauncherSettings.cs
+++ b/Launcher/LauncherSettings.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Tractus.HtmlToNdi.Launcher;
+
+public class LauncherSettings
+{
+    public string NdiName { get; set; } = "HTML5";
+
+    public int Port { get; set; } = 9999;
+
+    public string Url { get; set; } = "https://testpattern.tractusevents.com/";
+
+    public int Width { get; set; } = 1920;
+
+    public int Height { get; set; } = 1080;
+
+    public string FrameRate { get; set; } = "60";
+
+    public bool EnableOutputBuffer { get; set; }
+        = false;
+
+    public int BufferDepth { get; set; } = 3;
+
+    public double TelemetryIntervalSeconds { get; set; } = 10;
+
+    public string? WindowlessFrameRate { get; set; }
+        = null;
+
+    public bool DisableGpuVsync { get; set; }
+        = false;
+
+    public bool DisableFrameRateLimit { get; set; }
+        = false;
+
+    public IEnumerable<string> BuildArguments()
+    {
+        yield return $"--ndiname={NdiName}";
+        yield return $"--port={Port}";
+        yield return $"--url={Url}";
+        yield return $"--w={Width}";
+        yield return $"--h={Height}";
+
+        if (!string.IsNullOrWhiteSpace(FrameRate))
+        {
+            yield return $"--fps={FrameRate.Trim()}";
+        }
+
+        if (EnableOutputBuffer)
+        {
+            yield return "--enable-output-buffer";
+
+            if (BufferDepth > 0)
+            {
+                yield return $"--buffer-depth={BufferDepth}";
+            }
+        }
+
+        if (TelemetryIntervalSeconds > 0)
+        {
+            yield return $"--telemetry-interval={TelemetryIntervalSeconds.ToString(CultureInfo.InvariantCulture)}";
+        }
+
+        if (!string.IsNullOrWhiteSpace(WindowlessFrameRate))
+        {
+            yield return $"--windowless-frame-rate={WindowlessFrameRate.Trim()}";
+        }
+
+        if (DisableGpuVsync)
+        {
+            yield return "--disable-gpu-vsync";
+        }
+
+        if (DisableFrameRateLimit)
+        {
+            yield return "--disable-frame-rate-limit";
+        }
+    }
+}

--- a/Launcher/LauncherSettingsStorage.cs
+++ b/Launcher/LauncherSettingsStorage.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using Serilog;
+
+namespace Tractus.HtmlToNdi.Launcher;
+
+public static class LauncherSettingsStorage
+{
+    private const string FileName = "launcher-settings.json";
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+    };
+
+    public static LauncherSettings Load()
+    {
+        try
+        {
+            var path = Path.Combine(AppManagement.DataDirectory, FileName);
+            if (!File.Exists(path))
+            {
+                return new LauncherSettings();
+            }
+
+            var json = File.ReadAllText(path);
+            var settings = JsonSerializer.Deserialize<LauncherSettings>(json, SerializerOptions);
+            return settings ?? new LauncherSettings();
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to load launcher settings. Reverting to defaults.");
+            return new LauncherSettings();
+        }
+    }
+
+    public static void Save(LauncherSettings settings)
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(settings, SerializerOptions);
+            var path = Path.Combine(AppManagement.DataDirectory, FileName);
+            File.WriteAllText(path, json);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to save launcher settings to disk.");
+        }
+    }
+}

--- a/Tests/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
+++ b/Tests/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tractus.HtmlToNdi.csproj
+++ b/Tractus.HtmlToNdi.csproj
@@ -1,17 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <OutputType>Exe</OutputType>
-	  <TargetFramework>net8.0</TargetFramework>
+          <OutputType>Exe</OutputType>
+          <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	  <ApplicationManifest>app.manifest</ApplicationManifest>
-	  <Version>2024.12.3.1</Version>
-	  <ApplicationIcon>HtmlToNdi.ico</ApplicationIcon>
-	  <PlatformTarget>x64</PlatformTarget>
-	  <Platforms>AnyCPU;x64</Platforms>
-	  <Company>Tractus Events</Company>
+          <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+          <ApplicationManifest>app.manifest</ApplicationManifest>
+          <Version>2024.12.3.1</Version>
+          <ApplicationIcon>HtmlToNdi.ico</ApplicationIcon>
+          <PlatformTarget>x64</PlatformTarget>
+          <Platforms>AnyCPU;x64</Platforms>
+          <Company>Tractus Events</Company>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- add a Windows Forms launcher that captures runtime settings before booting the NDI pipeline
- persist the last used settings to disk so they reload automatically on the next launch
- retarget the main and test projects to net8.0-windows to support the new WinForms front end

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68db96c049148329a9c10ec15ca4965c