### PR TITLE
Add launcher UI for configuring HtmlToNdi runtime

### DIFF
--- a/Launcher/LaunchParameters.cs
+++ b/Launcher/LaunchParameters.cs
@@ -1,0 +1,268 @@
+using System.Globalization;
+using Tractus.HtmlToNdi.Video;
+
+namespace Tractus.HtmlToNdi.Launcher;
+
+public sealed class LaunchParameters
+{
+    private LaunchParameters(
+        string ndiName,
+        int port,
+        string startUrl,
+        int width,
+        int height,
+        FrameRate frameRate,
+        bool enableBuffering,
+        int bufferDepth,
+        TimeSpan telemetryInterval,
+        int? windowlessFrameRateOverride,
+        bool disableGpuVsync,
+        bool disableFrameRateLimit)
+    {
+        NdiName = ndiName;
+        Port = port;
+        StartUrl = startUrl;
+        Width = width;
+        Height = height;
+        FrameRate = frameRate;
+        EnableBuffering = enableBuffering;
+        BufferDepth = bufferDepth;
+        TelemetryInterval = telemetryInterval;
+        WindowlessFrameRateOverride = windowlessFrameRateOverride;
+        DisableGpuVsync = disableGpuVsync;
+        DisableFrameRateLimit = disableFrameRateLimit;
+    }
+
+    public string NdiName { get; }
+
+    public int Port { get; }
+
+    public string StartUrl { get; }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public FrameRate FrameRate { get; }
+
+    public bool EnableBuffering { get; }
+
+    public int BufferDepth { get; }
+
+    public TimeSpan TelemetryInterval { get; }
+
+    public int? WindowlessFrameRateOverride { get; }
+
+    public bool DisableGpuVsync { get; }
+
+    public bool DisableFrameRateLimit { get; }
+
+    public static bool TryFromArgs(string[] args, out LaunchParameters? parameters)
+    {
+        parameters = null;
+
+        string? GetArgValue(string switchName)
+            => args.FirstOrDefault(x => x.StartsWith($"{switchName}=", StringComparison.Ordinal))?
+                .Split('=', 2)[1];
+
+        bool HasFlag(string flag) => args.Any(x => x.Equals(flag, StringComparison.Ordinal));
+
+        var ndiName = GetArgValue("--ndiname") ?? "HTML5";
+        if (string.IsNullOrWhiteSpace(ndiName))
+        {
+            do
+            {
+                Console.Write("NDI source name >");
+                ndiName = Console.ReadLine()?.Trim();
+            }
+            while (string.IsNullOrWhiteSpace(ndiName));
+        }
+
+        var port = 9999;
+        var portArg = GetArgValue("--port");
+        if (portArg is not null)
+        {
+            if (!int.TryParse(portArg, NumberStyles.Integer, CultureInfo.InvariantCulture, out port))
+            {
+                Serilog.Log.Error("Could not parse the --port parameter. Exiting.");
+                return false;
+            }
+        }
+        else
+        {
+            var portNumber = "";
+            while (string.IsNullOrWhiteSpace(portNumber) || !int.TryParse(portNumber, out port))
+            {
+                Console.Write("HTTP API port # >");
+                portNumber = Console.ReadLine()?.Trim();
+            }
+        }
+
+        var startUrl = GetArgValue("--url") ?? "https://testpattern.tractusevents.com/";
+
+        if (!Uri.TryCreate(startUrl, UriKind.Absolute, out _))
+        {
+            Serilog.Log.Error("Invalid --url parameter. Exiting.");
+            return false;
+        }
+
+        var width = 1920;
+        var widthArg = GetArgValue("--w");
+        if (widthArg is not null && (!int.TryParse(widthArg, NumberStyles.Integer, CultureInfo.InvariantCulture, out width) || width <= 0))
+        {
+            Serilog.Log.Error("Could not parse the --w (width) parameter. Exiting.");
+            return false;
+        }
+
+        var height = 1080;
+        var heightArg = GetArgValue("--h");
+        if (heightArg is not null && (!int.TryParse(heightArg, NumberStyles.Integer, CultureInfo.InvariantCulture, out height) || height <= 0))
+        {
+            Serilog.Log.Error("Could not parse the --h (height) parameter. Exiting.");
+            return false;
+        }
+
+        FrameRate frameRate;
+        try
+        {
+            frameRate = FrameRate.Parse(GetArgValue("--fps"));
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Error(ex, "Could not parse the --fps parameter. Exiting.");
+            return false;
+        }
+
+        var bufferDepth = 0;
+        var bufferDepthArg = GetArgValue("--buffer-depth");
+        if (bufferDepthArg is not null && (!int.TryParse(bufferDepthArg, NumberStyles.Integer, CultureInfo.InvariantCulture, out bufferDepth) || bufferDepth < 0))
+        {
+            Serilog.Log.Error("Could not parse the --buffer-depth parameter. Exiting.");
+            return false;
+        }
+
+        var telemetryInterval = TimeSpan.FromSeconds(10);
+        var telemetryArg = GetArgValue("--telemetry-interval");
+        if (telemetryArg is not null)
+        {
+            if (!double.TryParse(telemetryArg, NumberStyles.Float, CultureInfo.InvariantCulture, out var telemetrySeconds) || telemetrySeconds <= 0)
+            {
+                Serilog.Log.Error("Could not parse the --telemetry-interval parameter. Exiting.");
+                return false;
+            }
+
+            telemetryInterval = TimeSpan.FromSeconds(telemetrySeconds);
+        }
+
+        bool disableGpuVsync = HasFlag("--disable-gpu-vsync");
+        bool disableFrameRateLimit = HasFlag("--disable-frame-rate-limit");
+
+        bool enableBuffering = HasFlag("--enable-output-buffer") || bufferDepth > 0;
+
+        int? windowlessFrameRateOverride = null;
+        var windowlessRateArg = GetArgValue("--windowless-frame-rate");
+        if (windowlessRateArg is not null)
+        {
+            if (double.TryParse(windowlessRateArg, NumberStyles.Float, CultureInfo.InvariantCulture, out var windowlessRate) && windowlessRate > 0)
+            {
+                windowlessFrameRateOverride = (int)Math.Clamp(Math.Round(windowlessRate), 1, 240);
+            }
+            else
+            {
+                Serilog.Log.Error("Could not parse the --windowless-frame-rate parameter. Exiting.");
+                return false;
+            }
+        }
+
+        parameters = new LaunchParameters(
+            ndiName,
+            port,
+            startUrl,
+            width,
+            height,
+            frameRate,
+            enableBuffering,
+            bufferDepth,
+            telemetryInterval,
+            windowlessFrameRateOverride,
+            disableGpuVsync,
+            disableFrameRateLimit);
+
+        return true;
+    }
+
+    public static LaunchParameters FromSettings(LauncherSettings settings)
+    {
+        if (settings is null)
+        {
+            throw new ArgumentNullException(nameof(settings));
+        }
+
+        FrameRate frameRate;
+        try
+        {
+            frameRate = FrameRate.Parse(settings.FrameRate);
+        }
+        catch (Exception ex)
+        {
+            throw new FormatException("The configured frame rate is invalid.", ex);
+        }
+
+        if (!Uri.TryCreate(settings.Url, UriKind.Absolute, out _))
+        {
+            throw new FormatException("The configured URL is invalid.");
+        }
+
+        int? windowlessFrameRateOverride = null;
+        if (!string.IsNullOrWhiteSpace(settings.WindowlessFrameRateOverride))
+        {
+            if (double.TryParse(settings.WindowlessFrameRateOverride, NumberStyles.Float, CultureInfo.InvariantCulture, out var windowlessRate) && windowlessRate > 0)
+            {
+                windowlessFrameRateOverride = (int)Math.Clamp(Math.Round(windowlessRate), 1, 240);
+            }
+            else
+            {
+                throw new FormatException("The windowless frame rate override must be a positive number.");
+            }
+        }
+
+        if (settings.Port <= 0 || settings.Port > 65535)
+        {
+            throw new FormatException("Port must be between 1 and 65535.");
+        }
+
+        if (settings.Width <= 0)
+        {
+            throw new FormatException("Width must be greater than zero.");
+        }
+
+        if (settings.Height <= 0)
+        {
+            throw new FormatException("Height must be greater than zero.");
+        }
+
+        if (settings.TelemetryIntervalSeconds <= 0)
+        {
+            throw new FormatException("Telemetry interval must be greater than zero.");
+        }
+
+        if (settings.EnableBuffering && settings.BufferDepth <= 0)
+        {
+            throw new FormatException("Buffer depth must be at least 1 when buffering is enabled.");
+        }
+
+        return new LaunchParameters(
+            settings.NdiName,
+            settings.Port,
+            settings.Url,
+            settings.Width,
+            settings.Height,
+            frameRate,
+            settings.EnableBuffering,
+            settings.EnableBuffering ? settings.BufferDepth : 0,
+            TimeSpan.FromSeconds(settings.TelemetryIntervalSeconds),
+            windowlessFrameRateOverride,
+            settings.DisableGpuVsync,
+            settings.DisableFrameRateLimit);
+    }
+}

--- a/Launcher/LauncherForm.cs
+++ b/Launcher/LauncherForm.cs
@@ -1,0 +1,272 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Tractus.HtmlToNdi.Launcher;
+
+public sealed class LauncherForm : Form
+{
+    private readonly TextBox _ndiNameTextBox;
+    private readonly NumericUpDown _portNumericUpDown;
+    private readonly TextBox _urlTextBox;
+    private readonly NumericUpDown _widthNumericUpDown;
+    private readonly NumericUpDown _heightNumericUpDown;
+    private readonly TextBox _frameRateTextBox;
+    private readonly CheckBox _enableBufferingCheckBox;
+    private readonly NumericUpDown _bufferDepthNumericUpDown;
+    private readonly NumericUpDown _telemetryNumericUpDown;
+    private readonly TextBox _windowlessFrameRateTextBox;
+    private readonly CheckBox _disableGpuVsyncCheckBox;
+    private readonly CheckBox _disableFrameRateLimitCheckBox;
+
+    public LaunchParameters? SelectedParameters { get; private set; }
+
+    public LauncherSettings? CurrentSettings { get; private set; }
+
+    public LauncherForm(LauncherSettings initialSettings)
+    {
+        if (initialSettings is null)
+        {
+            throw new ArgumentNullException(nameof(initialSettings));
+        }
+
+        Text = "Tractus HtmlToNdi Launcher";
+        FormBorderStyle = FormBorderStyle.FixedDialog;
+        MaximizeBox = false;
+        MinimizeBox = false;
+        StartPosition = FormStartPosition.CenterScreen;
+        AutoSize = true;
+        AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        Padding = new Padding(12);
+
+        var table = new TableLayoutPanel
+        {
+            ColumnCount = 2,
+            RowCount = 0,
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            Padding = new Padding(0),
+        };
+
+        table.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 45));
+        table.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 55));
+
+        Controls.Add(table);
+
+        _ndiNameTextBox = new TextBox { Dock = DockStyle.Fill };
+        AddRow(table, "NDI Source Name", _ndiNameTextBox);
+
+        _portNumericUpDown = new NumericUpDown
+        {
+            Minimum = 1,
+            Maximum = 65535,
+            Dock = DockStyle.Fill,
+            Increment = 1,
+        };
+        AddRow(table, "HTTP Port", _portNumericUpDown);
+
+        _urlTextBox = new TextBox { Dock = DockStyle.Fill };
+        AddRow(table, "Startup URL", _urlTextBox);
+
+        _widthNumericUpDown = new NumericUpDown
+        {
+            Minimum = 1,
+            Maximum = 10000,
+            Dock = DockStyle.Fill,
+            Increment = 1,
+        };
+        AddRow(table, "Width", _widthNumericUpDown);
+
+        _heightNumericUpDown = new NumericUpDown
+        {
+            Minimum = 1,
+            Maximum = 10000,
+            Dock = DockStyle.Fill,
+            Increment = 1,
+        };
+        AddRow(table, "Height", _heightNumericUpDown);
+
+        _frameRateTextBox = new TextBox { Dock = DockStyle.Fill };
+        AddRow(table, "Frame Rate (fps)", _frameRateTextBox);
+
+        _enableBufferingCheckBox = new CheckBox
+        {
+            Text = "Enable paced output buffer",
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+        };
+        AddRow(table, "Output Buffer", _enableBufferingCheckBox);
+
+        _bufferDepthNumericUpDown = new NumericUpDown
+        {
+            Minimum = 1,
+            Maximum = 60,
+            Dock = DockStyle.Fill,
+            Increment = 1,
+        };
+        AddRow(table, "Buffer Depth (frames)", _bufferDepthNumericUpDown);
+
+        _telemetryNumericUpDown = new NumericUpDown
+        {
+            Minimum = 1,
+            Maximum = 3600,
+            DecimalPlaces = 1,
+            Increment = 0.5M,
+            Dock = DockStyle.Fill,
+        };
+        AddRow(table, "Telemetry Interval (s)", _telemetryNumericUpDown);
+
+        _windowlessFrameRateTextBox = new TextBox { Dock = DockStyle.Fill };
+        AddRow(table, "Windowless Frame Rate", _windowlessFrameRateTextBox);
+
+        _disableGpuVsyncCheckBox = new CheckBox
+        {
+            Text = "Disable GPU VSync",
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+        };
+        AddRow(table, "GPU", _disableGpuVsyncCheckBox);
+
+        _disableFrameRateLimitCheckBox = new CheckBox
+        {
+            Text = "Disable frame rate limiter",
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+        };
+        AddRow(table, "Chromium", _disableFrameRateLimitCheckBox);
+
+        var buttonPanel = new FlowLayoutPanel
+        {
+            FlowDirection = FlowDirection.RightToLeft,
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink
+        };
+
+        var launchButton = new Button
+        {
+            Text = "Launch",
+            AutoSize = true,
+            Padding = new Padding(12, 6, 12, 6)
+        };
+        launchButton.Click += (_, _) => OnLaunch();
+
+        var cancelButton = new Button
+        {
+            Text = "Cancel",
+            DialogResult = DialogResult.Cancel,
+            AutoSize = true,
+            Padding = new Padding(12, 6, 12, 6)
+        };
+
+        buttonPanel.Controls.Add(launchButton);
+        buttonPanel.Controls.Add(cancelButton);
+
+        table.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        table.Controls.Add(new Panel(), 0, table.RowCount);
+        table.Controls.Add(buttonPanel, 1, table.RowCount);
+        table.RowCount++;
+
+        AcceptButton = launchButton;
+        CancelButton = cancelButton;
+
+        _enableBufferingCheckBox.CheckedChanged += (_, _) =>
+            _bufferDepthNumericUpDown.Enabled = _enableBufferingCheckBox.Checked;
+
+        ApplySettings(initialSettings);
+    }
+
+    private void ApplySettings(LauncherSettings settings)
+    {
+        _ndiNameTextBox.Text = settings.NdiName;
+        _portNumericUpDown.Value = Math.Clamp(settings.Port, (int)_portNumericUpDown.Minimum, (int)_portNumericUpDown.Maximum);
+        _urlTextBox.Text = settings.Url;
+        _widthNumericUpDown.Value = Math.Clamp(settings.Width, (int)_widthNumericUpDown.Minimum, (int)_widthNumericUpDown.Maximum);
+        _heightNumericUpDown.Value = Math.Clamp(settings.Height, (int)_heightNumericUpDown.Minimum, (int)_heightNumericUpDown.Maximum);
+        _frameRateTextBox.Text = settings.FrameRate;
+        _enableBufferingCheckBox.Checked = settings.EnableBuffering;
+        _bufferDepthNumericUpDown.Value = Math.Clamp(
+            settings.BufferDepth <= 0 ? 1 : settings.BufferDepth,
+            (int)_bufferDepthNumericUpDown.Minimum,
+            (int)_bufferDepthNumericUpDown.Maximum);
+        _bufferDepthNumericUpDown.Enabled = settings.EnableBuffering;
+        var telemetryValue = (decimal)Math.Clamp(settings.TelemetryIntervalSeconds, (double)_telemetryNumericUpDown.Minimum, (double)_telemetryNumericUpDown.Maximum);
+        _telemetryNumericUpDown.Value = telemetryValue;
+        _windowlessFrameRateTextBox.Text = settings.WindowlessFrameRateOverride ?? string.Empty;
+        _disableGpuVsyncCheckBox.Checked = settings.DisableGpuVsync;
+        _disableFrameRateLimitCheckBox.Checked = settings.DisableFrameRateLimit;
+    }
+
+    private void OnLaunch()
+    {
+        var ndiName = _ndiNameTextBox.Text.Trim();
+        if (string.IsNullOrWhiteSpace(ndiName))
+        {
+            MessageBox.Show(this, "Please enter an NDI source name.", "Validation", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            _ndiNameTextBox.Focus();
+            return;
+        }
+
+        var url = _urlTextBox.Text.Trim();
+        if (!Uri.TryCreate(url, UriKind.Absolute, out _))
+        {
+            MessageBox.Show(this, "Please enter a valid absolute URL.", "Validation", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            _urlTextBox.Focus();
+            return;
+        }
+
+        var frameRateText = _frameRateTextBox.Text.Trim();
+        if (string.IsNullOrWhiteSpace(frameRateText))
+        {
+            frameRateText = "60";
+        }
+
+        var settings = new LauncherSettings
+        {
+            NdiName = ndiName,
+            Port = (int)_portNumericUpDown.Value,
+            Url = url,
+            Width = (int)_widthNumericUpDown.Value,
+            Height = (int)_heightNumericUpDown.Value,
+            FrameRate = frameRateText,
+            EnableBuffering = _enableBufferingCheckBox.Checked,
+            BufferDepth = (int)_bufferDepthNumericUpDown.Value,
+            TelemetryIntervalSeconds = (double)_telemetryNumericUpDown.Value,
+            WindowlessFrameRateOverride = string.IsNullOrWhiteSpace(_windowlessFrameRateTextBox.Text)
+                ? null
+                : _windowlessFrameRateTextBox.Text.Trim(),
+            DisableGpuVsync = _disableGpuVsyncCheckBox.Checked,
+            DisableFrameRateLimit = _disableFrameRateLimitCheckBox.Checked
+        };
+
+        try
+        {
+            SelectedParameters = LaunchParameters.FromSettings(settings);
+            CurrentSettings = settings;
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+        catch (FormatException ex)
+        {
+            MessageBox.Show(this, ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+        }
+    }
+
+    private static void AddRow(TableLayoutPanel table, string labelText, Control control)
+    {
+        table.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+
+        var label = new Label
+        {
+            Text = labelText,
+            Dock = DockStyle.Fill,
+            TextAlign = ContentAlignment.MiddleLeft,
+            AutoSize = true,
+            Padding = new Padding(0, 4, 8, 4)
+        };
+
+        table.Controls.Add(label, 0, table.RowCount);
+        table.Controls.Add(control, 1, table.RowCount);
+        table.RowCount++;
+    }
+}

--- a/Launcher/LauncherSettings.cs
+++ b/Launcher/LauncherSettings.cs
@@ -1,0 +1,32 @@
+namespace Tractus.HtmlToNdi.Launcher;
+
+public class LauncherSettings
+{
+    public string NdiName { get; set; } = "HTML5";
+
+    public int Port { get; set; } = 9999;
+
+    public string Url { get; set; } = "https://testpattern.tractusevents.com/";
+
+    public int Width { get; set; } = 1920;
+
+    public int Height { get; set; } = 1080;
+
+    public string FrameRate { get; set; } = "60";
+
+    public bool EnableBuffering { get; set; }
+        = false;
+
+    public int BufferDepth { get; set; } = 3;
+
+    public double TelemetryIntervalSeconds { get; set; } = 10;
+
+    public string? WindowlessFrameRateOverride { get; set; }
+        = null;
+
+    public bool DisableGpuVsync { get; set; }
+        = false;
+
+    public bool DisableFrameRateLimit { get; set; }
+        = false;
+}

--- a/Launcher/LauncherSettingsStore.cs
+++ b/Launcher/LauncherSettingsStore.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+using Serilog;
+
+namespace Tractus.HtmlToNdi.Launcher;
+
+public static class LauncherSettingsStore
+{
+    private const string SettingsFileName = "launcher-settings.json";
+
+    public static LauncherSettings Load()
+    {
+        try
+        {
+            var path = Path.Combine(AppManagement.DataDirectory, SettingsFileName);
+            if (!File.Exists(path))
+            {
+                return new LauncherSettings();
+            }
+
+            var json = File.ReadAllText(path);
+            var settings = JsonSerializer.Deserialize<LauncherSettings>(json);
+            return settings ?? new LauncherSettings();
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to load launcher settings. Using defaults.");
+            return new LauncherSettings();
+        }
+    }
+
+    public static void Save(LauncherSettings settings)
+    {
+        if (settings is null)
+        {
+            throw new ArgumentNullException(nameof(settings));
+        }
+
+        try
+        {
+            var json = JsonSerializer.Serialize(settings, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+
+            var path = Path.Combine(AppManagement.DataDirectory, SettingsFileName);
+            File.WriteAllText(path, json);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to save launcher settings.");
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -12,8 +12,10 @@ using Serilog;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 using Tractus.HtmlToNdi.Chromium;
 using Tractus.HtmlToNdi.Models;
+using Tractus.HtmlToNdi.Launcher;
 using Tractus.HtmlToNdi.Video;
 
 namespace Tractus.HtmlToNdi;
@@ -22,124 +24,68 @@ public class Program
     public static nint NdiSenderPtr;
     public static CefWrapper browserWrapper;
 
+    [STAThread]
     public static void Main(string[] args)
     {
+        var sanitizedArgs = RemoveLauncherFlags(args);
+
         var launchCachePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "cache", Guid.NewGuid().ToString());
 
         var exeDirectory = AppDomain.CurrentDomain.BaseDirectory;
         Directory.SetCurrentDirectory(exeDirectory);
-        AppManagement.Initialize(args);
+        AppManagement.Initialize(sanitizedArgs);
 
-        string? GetArgValue(string switchName)
-            => args.FirstOrDefault(x => x.StartsWith($"{switchName}=", StringComparison.Ordinal))?
-                .Split('=', 2)[1];
-
-        bool HasFlag(string flag) => args.Any(x => x.Equals(flag, StringComparison.Ordinal));
-
-        var ndiName = GetArgValue("--ndiname") ?? "HTML5";
-        if (string.IsNullOrWhiteSpace(ndiName))
+        LaunchParameters? parameters;
+        if (ShouldUseLauncher(args))
         {
-            do
-            {
-                Console.Write("NDI source name >");
-                ndiName = Console.ReadLine()?.Trim();
-            }
-            while (string.IsNullOrWhiteSpace(ndiName));
-        }
+            Application.SetHighDpiMode(HighDpiMode.SystemAware);
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
 
-        var port = 9999;
-        var portArg = GetArgValue("--port");
-        if (portArg is not null)
-        {
-            if (!int.TryParse(portArg, NumberStyles.Integer, CultureInfo.InvariantCulture, out port))
+            var settings = LauncherSettingsStore.Load();
+            using var form = new LauncherForm(settings);
+            if (form.ShowDialog() != DialogResult.OK || form.SelectedParameters is null)
             {
-                Log.Error("Could not parse the --port parameter. Exiting.");
                 return;
             }
+
+            if (form.CurrentSettings is not null)
+            {
+                LauncherSettingsStore.Save(form.CurrentSettings);
+            }
+
+            parameters = form.SelectedParameters;
         }
         else
         {
-            var portNumber = "";
-            while (string.IsNullOrWhiteSpace(portNumber) || !int.TryParse(portNumber, out port))
+            if (!LaunchParameters.TryFromArgs(sanitizedArgs, out parameters) || parameters is null)
             {
-                Console.Write("HTTP API port # >");
-                portNumber = Console.ReadLine()?.Trim();
-            }
-        }
-
-        var startUrl = GetArgValue("--url") ?? "https://testpattern.tractusevents.com/";
-
-        if (!Uri.TryCreate(startUrl, UriKind.Absolute, out _))
-        {
-            Log.Error("Invalid --url parameter. Exiting.");
-            return;
-        }
-
-        var width = 1920;
-        var widthArg = GetArgValue("--w");
-        if (widthArg is not null && (!int.TryParse(widthArg, NumberStyles.Integer, CultureInfo.InvariantCulture, out width) || width <= 0))
-        {
-            Log.Error("Could not parse the --w (width) parameter. Exiting.");
-            return;
-        }
-
-        var height = 1080;
-        var heightArg = GetArgValue("--h");
-        if (heightArg is not null && (!int.TryParse(heightArg, NumberStyles.Integer, CultureInfo.InvariantCulture, out height) || height <= 0))
-        {
-            Log.Error("Could not parse the --h (height) parameter. Exiting.");
-            return;
-        }
-
-        var frameRate = FrameRate.Parse(GetArgValue("--fps"));
-
-        var bufferDepth = 0;
-        var bufferDepthArg = GetArgValue("--buffer-depth");
-        if (bufferDepthArg is not null && (!int.TryParse(bufferDepthArg, NumberStyles.Integer, CultureInfo.InvariantCulture, out bufferDepth) || bufferDepth < 0))
-        {
-            Log.Error("Could not parse the --buffer-depth parameter. Exiting.");
-            return;
-        }
-
-        var telemetryInterval = TimeSpan.FromSeconds(10);
-        var telemetryArg = GetArgValue("--telemetry-interval");
-        if (telemetryArg is not null)
-        {
-            if (!double.TryParse(telemetryArg, NumberStyles.Float, CultureInfo.InvariantCulture, out var telemetrySeconds) || telemetrySeconds <= 0)
-            {
-                Log.Error("Could not parse the --telemetry-interval parameter. Exiting.");
-                return;
-            }
-
-            telemetryInterval = TimeSpan.FromSeconds(telemetrySeconds);
-        }
-
-        var enableBuffering = HasFlag("--enable-output-buffer") || bufferDepth > 0;
-        var effectiveDepth = enableBuffering ? Math.Max(1, bufferDepth == 0 ? 3 : bufferDepth) : 1;
-
-        int? windowlessFrameRateOverride = null;
-        var windowlessRateArg = GetArgValue("--windowless-frame-rate");
-        if (windowlessRateArg is not null)
-        {
-            if (double.TryParse(windowlessRateArg, NumberStyles.Float, CultureInfo.InvariantCulture, out var windowlessRate) && windowlessRate > 0)
-            {
-                windowlessFrameRateOverride = (int)Math.Clamp(Math.Round(windowlessRate), 1, 240);
-            }
-            else
-            {
-                Log.Error("Could not parse the --windowless-frame-rate parameter. Exiting.");
                 return;
             }
         }
+
+        RunApplication(parameters, sanitizedArgs, launchCachePath);
+    }
+
+    private static void RunApplication(LaunchParameters parameters, string[] args, string launchCachePath)
+    {
+        var frameRate = parameters.FrameRate;
+        var width = parameters.Width;
+        var height = parameters.Height;
+        var startUrl = parameters.StartUrl;
+        var windowlessFrameRateOverride = parameters.WindowlessFrameRateOverride;
+
+        var enableBuffering = parameters.EnableBuffering;
+        var effectiveDepth = enableBuffering ? Math.Max(1, parameters.BufferDepth == 0 ? 3 : parameters.BufferDepth) : 1;
 
         var pipelineOptions = new NdiVideoPipelineOptions
         {
             EnableBuffering = enableBuffering,
             BufferDepth = effectiveDepth,
-            TelemetryInterval = telemetryInterval,
+            TelemetryInterval = parameters.TelemetryInterval,
         };
 
-        var ndiNamePtr = UTF.StringToUtf8(ndiName);
+        var ndiNamePtr = UTF.StringToUtf8(parameters.NdiName);
         try
         {
             var settings_T = new NDIlib.send_create_t
@@ -182,12 +128,12 @@ public class Program
                 var targetWindowlessRate = windowlessFrameRateOverride ?? Math.Clamp((int)Math.Round(frameRate.Value), 1, 240);
                 settings.CefCommandLineArgs.Add("off-screen-frame-rate", targetWindowlessRate.ToString(CultureInfo.InvariantCulture));
 
-                if (HasFlag("--disable-gpu-vsync"))
+                if (parameters.DisableGpuVsync)
                 {
                     settings.CefCommandLineArgs.Add("disable-gpu-vsync", "1");
                 }
 
-                if (HasFlag("--disable-frame-rate-limit"))
+                if (parameters.DisableFrameRateLimit)
                 {
                     settings.CefCommandLineArgs.Add("disable-frame-rate-limit", "1");
                 }
@@ -217,7 +163,7 @@ public class Program
 
         builder.Services.AddSerilog();
 
-        builder.WebHost.UseUrls($"http://*:{port}");
+        builder.WebHost.UseUrls($"http://*:{parameters.Port}");
 
         // Add services to the container.
         builder.Services.AddAuthorization();
@@ -357,4 +303,53 @@ public class Program
             }
         }
     }
+
+    private static string[] RemoveLauncherFlags(string[] args)
+        => args.Where(a => !string.Equals(a, "--launcher", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(a, "--no-launcher", StringComparison.OrdinalIgnoreCase)).ToArray();
+
+    private static bool ShouldUseLauncher(string[] args)
+    {
+        if (args.Any(a => string.Equals(a, "--launcher", StringComparison.OrdinalIgnoreCase)))
+        {
+            return true;
+        }
+
+        if (args.Any(a => string.Equals(a, "--no-launcher", StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
+        foreach (var arg in args)
+        {
+            if (!arg.StartsWith("--", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var switchName = arg.Split('=', 2)[0];
+            if (ConfigurationSwitches.Contains(switchName))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static readonly HashSet<string> ConfigurationSwitches = new(StringComparer.Ordinal)
+    {
+        "--ndiname",
+        "--port",
+        "--url",
+        "--w",
+        "--h",
+        "--fps",
+        "--buffer-depth",
+        "--telemetry-interval",
+        "--windowless-frame-rate",
+        "--enable-output-buffer",
+        "--disable-gpu-vsync",
+        "--disable-frame-rate-limit",
+    };
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A simple wrapper around [CEFSharp](https://github.com/cefsharp/CefSharp) and [ND
 
 ## Usage
 
-Launch as-is for a 1920x1080 browser instance. The app will ask you for a source name if one is not provided on the command line.
+Launching the executable without command-line parameters now opens a simple launcher window. The launcher loads the most recent
+settings, lets you tweak NDI, HTTP and rendering options, and starts the application when you press **Launch**. Settings are
+written to `launcher-settings.json` beside the executable and reused next time you open the tool.
 
 If the web page you are loading has a transparent background, NDI will honor that transparency.
 
@@ -26,6 +28,8 @@ Parameter|Description
 `--windowless-frame-rate=60`|Overrides CEF's internal repaint cadence. Defaults to the nearest integer of `--fps`.
 `--disable-gpu-vsync`|Disables Chromium's GPU vsync throttling.
 `--disable-frame-rate-limit`|Disables Chromium's frame rate limiter.
+`--launcher`|Forces the launcher window to appear even when other parameters are supplied.
+`--no-launcher`|Skips the launcher and honours the supplied command-line arguments only.
 
 #### Example Launch
 

--- a/Tractus.HtmlToNdi.csproj
+++ b/Tractus.HtmlToNdi.csproj
@@ -1,17 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <OutputType>Exe</OutputType>
-	  <TargetFramework>net8.0</TargetFramework>
+          <OutputType>Exe</OutputType>
+          <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	  <ApplicationManifest>app.manifest</ApplicationManifest>
-	  <Version>2024.12.3.1</Version>
-	  <ApplicationIcon>HtmlToNdi.ico</ApplicationIcon>
-	  <PlatformTarget>x64</PlatformTarget>
-	  <Platforms>AnyCPU;x64</Platforms>
-	  <Company>Tractus Events</Company>
+          <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+          <ApplicationManifest>app.manifest</ApplicationManifest>
+          <Version>2024.12.3.1</Version>
+          <ApplicationIcon>HtmlToNdi.ico</ApplicationIcon>
+          <PlatformTarget>x64</PlatformTarget>
+          <Platforms>AnyCPU;x64</Platforms>
+          <Company>Tractus Events</Company>
+          <UseWindowsForms>true</UseWindowsForms>
+          <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- add a Windows Forms launcher that surfaces the common runtime settings and starts the app without command-line switches
- persist the last-used configuration in launcher-settings.json and reuse the same validation logic for both the GUI and CLI paths
- update Program.cs, project settings, and docs to support the launcher and new --launcher/--no-launcher overrides

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68db96c049148329a9c10ec15ca4965c