### PR TITLE
Add WinForms launcher and align Windows targeting

### DIFF
--- a/Launcher/LaunchConfiguration.cs
+++ b/Launcher/LaunchConfiguration.cs
@@ -1,0 +1,100 @@
+using System;
+using Tractus.HtmlToNdi.Video;
+
+namespace Tractus.HtmlToNdi.Launcher;
+
+internal sealed class LaunchConfiguration
+{
+    public LaunchConfiguration(
+        string ndiName,
+        int port,
+        string url,
+        int width,
+        int height,
+        FrameRate frameRate,
+        string frameRateText,
+        bool enableBuffering,
+        int bufferDepth,
+        TimeSpan telemetryInterval,
+        int? windowlessFrameRateOverride,
+        string? windowlessFrameRateText,
+        bool disableGpuVsync,
+        bool disableFrameRateLimit)
+    {
+        NdiName = ndiName;
+        Port = port;
+        Url = url;
+        Width = width;
+        Height = height;
+        FrameRate = frameRate;
+        FrameRateText = frameRateText;
+        EnableBuffering = enableBuffering;
+        BufferDepth = bufferDepth;
+        TelemetryInterval = telemetryInterval;
+        WindowlessFrameRateOverride = windowlessFrameRateOverride;
+        WindowlessFrameRateText = windowlessFrameRateText;
+        DisableGpuVsync = disableGpuVsync;
+        DisableFrameRateLimit = disableFrameRateLimit;
+    }
+
+    public string NdiName { get; }
+
+    public int Port { get; }
+
+    public string Url { get; }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public FrameRate FrameRate { get; }
+
+    public string FrameRateText { get; }
+
+    public bool EnableBuffering { get; }
+
+    public int BufferDepth { get; }
+
+    public TimeSpan TelemetryInterval { get; }
+
+    public int? WindowlessFrameRateOverride { get; }
+
+    public string? WindowlessFrameRateText { get; }
+
+    public bool DisableGpuVsync { get; }
+
+    public bool DisableFrameRateLimit { get; }
+
+    public LaunchConfiguration With(
+        string? ndiName = null,
+        int? port = null,
+        string? url = null,
+        int? width = null,
+        int? height = null,
+        FrameRate? frameRate = null,
+        string? frameRateText = null,
+        bool? enableBuffering = null,
+        int? bufferDepth = null,
+        TimeSpan? telemetryInterval = null,
+        int? windowlessFrameRateOverride = null,
+        string? windowlessFrameRateText = null,
+        bool? disableGpuVsync = null,
+        bool? disableFrameRateLimit = null)
+    {
+        return new LaunchConfiguration(
+            ndiName ?? NdiName,
+            port ?? Port,
+            url ?? Url,
+            width ?? Width,
+            height ?? Height,
+            frameRate ?? FrameRate,
+            frameRateText ?? FrameRateText,
+            enableBuffering ?? EnableBuffering,
+            bufferDepth ?? BufferDepth,
+            telemetryInterval ?? TelemetryInterval,
+            windowlessFrameRateOverride ?? WindowlessFrameRateOverride,
+            windowlessFrameRateText ?? WindowlessFrameRateText,
+            disableGpuVsync ?? DisableGpuVsync,
+            disableFrameRateLimit ?? DisableFrameRateLimit);
+    }
+}

--- a/Launcher/LauncherForm.cs
+++ b/Launcher/LauncherForm.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Drawing;
+using System.Globalization;
+using System.Windows.Forms;
+using Tractus.HtmlToNdi.Video;
+
+namespace Tractus.HtmlToNdi.Launcher;
+
+internal sealed class LauncherForm : Form
+{
+    private readonly TextBox _ndiNameTextBox;
+    private readonly NumericUpDown _portNumeric;
+    private readonly TextBox _urlTextBox;
+    private readonly NumericUpDown _widthNumeric;
+    private readonly NumericUpDown _heightNumeric;
+    private readonly TextBox _frameRateTextBox;
+    private readonly CheckBox _bufferingCheckBox;
+    private readonly NumericUpDown _bufferDepthNumeric;
+    private readonly NumericUpDown _telemetryNumeric;
+    private readonly TextBox _windowlessFrameRateTextBox;
+    private readonly CheckBox _disableVsyncCheckBox;
+    private readonly CheckBox _disableFrameLimitCheckBox;
+
+    public LauncherForm(LaunchConfiguration configuration)
+    {
+        Text = "Tractus HTML to NDI";
+        StartPosition = FormStartPosition.CenterScreen;
+        FormBorderStyle = FormBorderStyle.FixedDialog;
+        MaximizeBox = false;
+        MinimizeBox = false;
+        AutoSize = true;
+        AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        Font = new Font(Font.FontFamily, 9.0f, FontStyle.Regular, GraphicsUnit.Point);
+
+        var layout = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 2,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            Padding = new Padding(10),
+        };
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f));
+
+        Controls.Add(layout);
+
+        _ndiNameTextBox = new TextBox { Width = 260 };
+        _portNumeric = new NumericUpDown
+        {
+            Minimum = 1,
+            Maximum = 65535,
+            Width = 120
+        };
+        _urlTextBox = new TextBox { Width = 260 };
+        _widthNumeric = new NumericUpDown
+        {
+            Minimum = 320,
+            Maximum = 7680,
+            Width = 120
+        };
+        _heightNumeric = new NumericUpDown
+        {
+            Minimum = 240,
+            Maximum = 4320,
+            Width = 120
+        };
+        _frameRateTextBox = new TextBox { Width = 120 };
+        _bufferingCheckBox = new CheckBox { Text = "Enable paced output buffer" };
+        _bufferDepthNumeric = new NumericUpDown
+        {
+            Minimum = 1,
+            Maximum = 60,
+            Width = 120
+        };
+        _telemetryNumeric = new NumericUpDown
+        {
+            Minimum = 1,
+            Maximum = 300,
+            Width = 120
+        };
+        _windowlessFrameRateTextBox = new TextBox { Width = 120 };
+        _disableVsyncCheckBox = new CheckBox { Text = "Disable GPU VSync" };
+        _disableFrameLimitCheckBox = new CheckBox { Text = "Disable frame rate limit" };
+
+        AddRow(layout, "NDI source name", _ndiNameTextBox);
+        AddRow(layout, "Startup URL", _urlTextBox);
+        AddRow(layout, "HTTP port", _portNumeric);
+        AddRow(layout, "Browser width", _widthNumeric);
+        AddRow(layout, "Browser height", _heightNumeric);
+        AddRow(layout, "Target FPS", _frameRateTextBox);
+
+        var bufferPanel = new FlowLayoutPanel
+        {
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            FlowDirection = FlowDirection.LeftToRight,
+            WrapContents = false
+        };
+        bufferPanel.Controls.Add(_bufferingCheckBox);
+        bufferPanel.Controls.Add(new Label { Text = "Depth", AutoSize = true, Padding = new Padding(10, 3, 0, 0) });
+        bufferPanel.Controls.Add(_bufferDepthNumeric);
+        AddRow(layout, "Output buffering", bufferPanel);
+
+        AddRow(layout, "Telemetry (s)", _telemetryNumeric);
+        AddRow(layout, "Windowless FPS", _windowlessFrameRateTextBox);
+        AddRow(layout, string.Empty, _disableVsyncCheckBox);
+        AddRow(layout, string.Empty, _disableFrameLimitCheckBox);
+
+        var buttonsPanel = new FlowLayoutPanel
+        {
+            FlowDirection = FlowDirection.RightToLeft,
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+            Margin = new Padding(0, 15, 0, 0)
+        };
+
+        var launchButton = new Button
+        {
+            Text = "Launch",
+            DialogResult = DialogResult.OK,
+            AutoSize = true,
+            Padding = new Padding(15, 5, 15, 5)
+        };
+        launchButton.Click += OnLaunchClicked;
+
+        var cancelButton = new Button
+        {
+            Text = "Cancel",
+            DialogResult = DialogResult.Cancel,
+            AutoSize = true,
+            Padding = new Padding(15, 5, 15, 5)
+        };
+
+        buttonsPanel.Controls.Add(launchButton);
+        buttonsPanel.Controls.Add(cancelButton);
+        layout.Controls.Add(buttonsPanel, 0, layout.RowCount);
+        layout.SetColumnSpan(buttonsPanel, 2);
+
+        AcceptButton = launchButton;
+        CancelButton = cancelButton;
+
+        _bufferingCheckBox.CheckedChanged += (_, _) => UpdateBufferControls();
+
+        ApplyConfiguration(configuration);
+        UpdateBufferControls();
+    }
+
+    public LaunchConfiguration? Result { get; private set; }
+
+    private void ApplyConfiguration(LaunchConfiguration configuration)
+    {
+        _ndiNameTextBox.Text = configuration.NdiName;
+        _portNumeric.Value = Math.Min(Math.Max(configuration.Port, (int)_portNumeric.Minimum), (int)_portNumeric.Maximum);
+        _urlTextBox.Text = configuration.Url;
+        _widthNumeric.Value = Math.Min(Math.Max(configuration.Width, (int)_widthNumeric.Minimum), (int)_widthNumeric.Maximum);
+        _heightNumeric.Value = Math.Min(Math.Max(configuration.Height, (int)_heightNumeric.Minimum), (int)_heightNumeric.Maximum);
+        _frameRateTextBox.Text = configuration.FrameRateText;
+        _bufferingCheckBox.Checked = configuration.EnableBuffering;
+        var depth = configuration.BufferDepth > 0 ? configuration.BufferDepth : 3;
+        _bufferDepthNumeric.Value = Math.Min(Math.Max(depth, (int)_bufferDepthNumeric.Minimum), (int)_bufferDepthNumeric.Maximum);
+        _telemetryNumeric.Value = Math.Min(Math.Max((decimal)configuration.TelemetryInterval.TotalSeconds, _telemetryNumeric.Minimum), _telemetryNumeric.Maximum);
+        _windowlessFrameRateTextBox.Text = configuration.WindowlessFrameRateText ?? string.Empty;
+        _disableVsyncCheckBox.Checked = configuration.DisableGpuVsync;
+        _disableFrameLimitCheckBox.Checked = configuration.DisableFrameRateLimit;
+    }
+
+    private void UpdateBufferControls()
+    {
+        _bufferDepthNumeric.Enabled = _bufferingCheckBox.Checked;
+    }
+
+    private void OnLaunchClicked(object? sender, EventArgs e)
+    {
+        var ndiName = _ndiNameTextBox.Text.Trim();
+        if (string.IsNullOrWhiteSpace(ndiName))
+        {
+            ShowValidationError("NDI source name is required.");
+            DialogResult = DialogResult.None;
+            return;
+        }
+
+        var urlText = _urlTextBox.Text.Trim();
+        if (!Uri.TryCreate(urlText, UriKind.Absolute, out _))
+        {
+            ShowValidationError("Enter a valid absolute URL.");
+            DialogResult = DialogResult.None;
+            return;
+        }
+
+        FrameRate frameRate;
+        try
+        {
+            frameRate = FrameRate.Parse(_frameRateTextBox.Text);
+        }
+        catch (Exception ex) when (ex is FormatException or ArgumentOutOfRangeException)
+        {
+            ShowValidationError("Enter a valid frame rate (number or fraction).");
+            DialogResult = DialogResult.None;
+            return;
+        }
+
+        var enableBuffering = _bufferingCheckBox.Checked;
+        var bufferDepth = enableBuffering ? (int)_bufferDepthNumeric.Value : 0;
+        var telemetryInterval = TimeSpan.FromSeconds((double)_telemetryNumeric.Value);
+
+        int? windowlessFrameRateOverride = null;
+        var windowlessText = _windowlessFrameRateTextBox.Text.Trim();
+        if (!string.IsNullOrEmpty(windowlessText))
+        {
+            if (!double.TryParse(windowlessText, NumberStyles.Float, CultureInfo.InvariantCulture, out var windowlessValue) || windowlessValue <= 0)
+            {
+                ShowValidationError("Enter a valid windowless frame rate override.");
+                DialogResult = DialogResult.None;
+                return;
+            }
+
+            windowlessFrameRateOverride = (int)Math.Clamp(Math.Round(windowlessValue), 1, 240);
+        }
+
+        Result = new LaunchConfiguration(
+            ndiName,
+            (int)_portNumeric.Value,
+            urlText,
+            (int)_widthNumeric.Value,
+            (int)_heightNumeric.Value,
+            frameRate,
+            _frameRateTextBox.Text.Trim().Length > 0 ? _frameRateTextBox.Text.Trim() : configurationFallback(frameRate),
+            enableBuffering,
+            bufferDepth,
+            telemetryInterval,
+            windowlessFrameRateOverride,
+            string.IsNullOrEmpty(windowlessText) ? null : windowlessText,
+            _disableVsyncCheckBox.Checked,
+            _disableFrameLimitCheckBox.Checked);
+    }
+
+    private static string configurationFallback(FrameRate frameRate)
+    {
+        return frameRate.ToString();
+    }
+
+    private static void AddRow(TableLayoutPanel layout, string labelText, Control control)
+    {
+        var rowIndex = layout.RowCount;
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        var label = new Label
+        {
+            Text = labelText,
+            TextAlign = ContentAlignment.MiddleLeft,
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+            Margin = new Padding(0, 6, 15, 6)
+        };
+
+        layout.Controls.Add(label, 0, rowIndex);
+        control.Margin = new Padding(0, 6, 0, 6);
+        layout.Controls.Add(control, 1, rowIndex);
+        layout.RowCount++;
+    }
+
+    private static void ShowValidationError(string message)
+    {
+        MessageBox.Show(message, "Tractus HTML to NDI", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple wrapper around [CEFSharp](https://github.com/cefsharp/CefSharp) and [ND
 
 ## Usage
 
-Launch as-is for a 1920x1080 browser instance. The app will ask you for a source name if one is not provided on the command line.
+Launch as-is for a 1920x1080 browser instance. When no command-line switches are supplied a Windows launcher dialog appears so you can choose the NDI source name, dimensions, frame rate, buffering, and other options interactively. Pass `--launcher` to force the dialog to appear, or `--no-launcher` to skip it even when no switches are present. The app will ask you for a source name if one is not provided on the command line or through the launcher.
 
 If the web page you are loading has a transparent background, NDI will honor that transparency.
 
@@ -26,6 +26,8 @@ Parameter|Description
 `--windowless-frame-rate=60`|Overrides CEF's internal repaint cadence. Defaults to the nearest integer of `--fps`.
 `--disable-gpu-vsync`|Disables Chromium's GPU vsync throttling.
 `--disable-frame-rate-limit`|Disables Chromium's frame rate limiter.
+`--launcher`|Always display the launcher UI before starting the headless renderer.
+`--no-launcher`|Never display the launcher UI (even when no other switches are provided).
 
 #### Example Launch
 

--- a/Tests/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
+++ b/Tests/Tractus.HtmlToNdi.Tests/Tractus.HtmlToNdi.Tests.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tractus.HtmlToNdi.csproj
+++ b/Tractus.HtmlToNdi.csproj
@@ -1,18 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <OutputType>Exe</OutputType>
-	  <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	  <ApplicationManifest>app.manifest</ApplicationManifest>
-	  <Version>2024.12.3.1</Version>
-	  <ApplicationIcon>HtmlToNdi.ico</ApplicationIcon>
-	  <PlatformTarget>x64</PlatformTarget>
-	  <Platforms>AnyCPU;x64</Platforms>
-	  <Company>Tractus Events</Company>
-
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <Version>2024.12.3.1</Version>
+    <ApplicationIcon>HtmlToNdi.ico</ApplicationIcon>
+    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>AnyCPU;x64</Platforms>
+    <Company>Tractus Events</Company>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add a WinForms launcher dialog that collects configuration when no CLI switches are provided and can be toggled with new --launcher/--no-launcher flags
- refactor Program startup to share validation between CLI parsing and the launcher while preserving NDI/CEF initialization behaviour
- retarget the app and tests to net8.0-windows with Windows Forms enabled, update docs, and record the launcher in the project guide

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dba1837b008329bc71c1c31fb495a7