### PR TITLE
Add warm-up gating and underrun telemetry to paced pipeline

### DIFF
--- a/Tests/Tractus.HtmlToNdi.Tests/FrameRingBufferTests.cs
+++ b/Tests/Tractus.HtmlToNdi.Tests/FrameRingBufferTests.cs
@@ -58,4 +58,37 @@ public class FrameRingBufferTests
         Assert.True(second.Disposed);
         Assert.Equal(2, buffer.DroppedAsStale);
     }
+
+    [Fact]
+    public void TryDequeueReturnsOldestWithoutDisposingOthers()
+    {
+        var buffer = new FrameRingBuffer<DisposableStub>(3);
+        var first = new DisposableStub();
+        var second = new DisposableStub();
+        var third = new DisposableStub();
+
+        buffer.Enqueue(first, out _);
+        buffer.Enqueue(second, out _);
+        buffer.Enqueue(third, out _);
+
+        var success = buffer.TryDequeue(out var dequeued);
+
+        Assert.True(success);
+        Assert.Same(first, dequeued);
+        Assert.False(second.Disposed);
+        Assert.False(third.Disposed);
+
+        dequeued?.Dispose();
+    }
+
+    [Fact]
+    public void TryDequeueReturnsFalseWhenEmpty()
+    {
+        var buffer = new FrameRingBuffer<DisposableStub>(2);
+
+        var success = buffer.TryDequeue(out var dequeued);
+
+        Assert.False(success);
+        Assert.Null(dequeued);
+    }
 }

--- a/Tests/Tractus.HtmlToNdi.Tests/NdiVideoPipelineTests.cs
+++ b/Tests/Tractus.HtmlToNdi.Tests/NdiVideoPipelineTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Serilog;
@@ -141,6 +142,7 @@ public class NdiVideoPipelineTests
             Assert.Equal(2, Marshal.ReadInt32(frames[1].p_data));
             Assert.Equal(3, Marshal.ReadInt32(frames[2].p_data));
             Assert.True(pipeline.BufferPrimed);
+            Assert.True(pipeline.LastWarmupDuration > TimeSpan.Zero);
         }
         finally
         {
@@ -211,6 +213,7 @@ public class NdiVideoPipelineTests
             Assert.True(indexOfThree >= 0, "Expected frame with marker 3 to be sent");
             Assert.True(indexOfFour > indexOfThree, "Expected frame with marker 4 after marker 3");
             Assert.True(pipeline.BufferPrimed);
+            Assert.True(pipeline.LastWarmupDuration > TimeSpan.Zero);
         }
         finally
         {

--- a/Tests/Tractus.HtmlToNdi.Tests/NdiVideoPipelineTests.cs
+++ b/Tests/Tractus.HtmlToNdi.Tests/NdiVideoPipelineTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Runtime.InteropServices;
 using Serilog;
 using Serilog.Core;
@@ -100,6 +101,128 @@ public class NdiVideoPipelineTests
         var frames = sender.Frames;
         Assert.True(frames.Count >= 2, "Expected at least one repeat frame");
         Assert.Equal(frames[0].p_data, frames[1].p_data);
+    }
+
+    [Fact]
+    public async Task BufferedModeWarmsUpBeforeSendingAndUsesFifo()
+    {
+        var sender = new CollectingSender();
+        var options = new NdiVideoPipelineOptions
+        {
+            EnableBuffering = true,
+            BufferDepth = 3,
+            TelemetryInterval = TimeSpan.FromDays(1)
+        };
+
+        var pipeline = new NdiVideoPipeline(sender, new FrameRate(1, 1), options, CreateNullLogger());
+        pipeline.Start();
+
+        var size = 4 * 2 * 2;
+        var buffers = new IntPtr[3];
+
+        try
+        {
+            await Task.Delay(500);
+            Assert.Empty(sender.Frames);
+
+            for (var i = 0; i < buffers.Length; i++)
+            {
+                buffers[i] = Marshal.AllocHGlobal(size);
+                Marshal.WriteInt32(buffers[i], i + 1);
+                var frame = new CapturedFrame(buffers[i], 2, 2, 8);
+                pipeline.HandleFrame(frame);
+            }
+
+            await Task.Delay(3500);
+
+            var frames = sender.Frames;
+            Assert.True(frames.Count >= 3);
+            Assert.Equal(1, Marshal.ReadInt32(frames[0].p_data));
+            Assert.Equal(2, Marshal.ReadInt32(frames[1].p_data));
+            Assert.Equal(3, Marshal.ReadInt32(frames[2].p_data));
+            Assert.True(pipeline.BufferPrimed);
+        }
+        finally
+        {
+            pipeline.Dispose();
+            foreach (var ptr in buffers)
+            {
+                if (ptr != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(ptr);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task BufferedModeCountsUnderrunsAndRewarms()
+    {
+        var sender = new CollectingSender();
+        var options = new NdiVideoPipelineOptions
+        {
+            EnableBuffering = true,
+            BufferDepth = 2,
+            TelemetryInterval = TimeSpan.FromDays(1)
+        };
+
+        var pipeline = new NdiVideoPipeline(sender, new FrameRate(5, 1), options, CreateNullLogger());
+        pipeline.Start();
+
+        var size = 4 * 2 * 2;
+        var buffers = new IntPtr[4];
+
+        try
+        {
+            for (var i = 0; i < 2; i++)
+            {
+                buffers[i] = Marshal.AllocHGlobal(size);
+                Marshal.WriteInt32(buffers[i], i + 1);
+                pipeline.HandleFrame(new CapturedFrame(buffers[i], 2, 2, 8));
+            }
+
+            await Task.Delay(1200);
+
+            var firstBurst = sender.Frames;
+            Assert.True(firstBurst.Count >= 2);
+            Assert.Equal(1, Marshal.ReadInt32(firstBurst[0].p_data));
+            Assert.Equal(2, Marshal.ReadInt32(firstBurst[1].p_data));
+            Assert.True(pipeline.BufferPrimed);
+
+            await Task.Delay(600);
+
+            Assert.True(pipeline.BufferUnderruns >= 1);
+            Assert.False(pipeline.BufferPrimed);
+
+            for (var i = 2; i < 4; i++)
+            {
+                buffers[i] = Marshal.AllocHGlobal(size);
+                Marshal.WriteInt32(buffers[i], i + 1);
+                pipeline.HandleFrame(new CapturedFrame(buffers[i], 2, 2, 8));
+            }
+
+            await Task.Delay(1200);
+
+            var frames = sender.Frames;
+            var values = frames.Select(f => Marshal.ReadInt32(f.p_data)).ToArray();
+            var indexOfThree = Array.IndexOf(values, 3);
+            var indexOfFour = Array.LastIndexOf(values, 4);
+
+            Assert.True(indexOfThree >= 0, "Expected frame with marker 3 to be sent");
+            Assert.True(indexOfFour > indexOfThree, "Expected frame with marker 4 after marker 3");
+            Assert.True(pipeline.BufferPrimed);
+        }
+        finally
+        {
+            pipeline.Dispose();
+            foreach (var ptr in buffers)
+            {
+                if (ptr != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(ptr);
+                }
+            }
+        }
     }
 }
 

--- a/Video/FrameRingBuffer.cs
+++ b/Video/FrameRingBuffer.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Tractus.HtmlToNdi.Video;
 
 internal sealed class FrameRingBuffer<T>
@@ -51,6 +53,26 @@ internal sealed class FrameRingBuffer<T>
             }
 
             frames.Enqueue(frame);
+        }
+    }
+
+    public bool TryDequeue([NotNullWhen(true)] out T? frame)
+    {
+        lock (frames)
+        {
+            if (frames.Count == 0)
+            {
+                frame = null;
+                return false;
+            }
+
+            frame = frames.Dequeue();
+            if (overflowSinceLastDequeue > 0)
+            {
+                overflowSinceLastDequeue--;
+            }
+
+            return true;
         }
     }
 


### PR DESCRIPTION
## Summary
- add FIFO dequeue support to the frame ring buffer and update the paced NDI loop to wait for the bucket to fill before sending
- track underruns, warm-up duration, and primed state in the paced sender while falling back to frame repeats only on underruns
- extend unit tests and documentation to cover FIFO behaviour, warm-up gating, underrun recovery, and the new telemetry fields

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4a48f196c8329889d42d64dbfe655