### PR TITLE
Stabilize paced buffering with constant-latency warmup

### DIFF
--- a/Docs/paced-output-buffer.md
+++ b/Docs/paced-output-buffer.md
@@ -1,7 +1,7 @@
 # Paced output buffer behaviour
 
 ## Summary
-This note explains how the video pipeline behaves when the paced output buffer is enabled versus disabled, and why the paced mode currently introduces visible stutter even though it is meant to smooth the stream.
+This note explains how the video pipeline behaves when the paced output buffer is enabled versus disabled, and documents the warm-up and underrun rules that keep latency predictable while smoothing cadence.
 
 ## What drives Chromium renders
 Chromium repaints are driven by `FramePump`. The pump wakes on a `PeriodicTimer` whose interval is derived from the configured frame rate, calls `Invalidate` on the browser host, and relies on CefSharp to raise `Paint` callbacks afterwards. A watchdog issues an extra invalidate if paints stop arriving for more than a second.【F:Video/FramePump.cs†L21-L74】
@@ -9,23 +9,18 @@ Chromium repaints are driven by `FramePump`. The pump wakes on a `PeriodicTimer`
 Each `Paint` event is forwarded to `NdiVideoPipeline.HandleFrame`, which wraps the buffer and hands it to the pipeline.【F:Chromium/CefWrapper.cs†L48-L82】
 
 ## Pipeline behaviour without buffering
-When buffering is disabled the pipeline immediately sends each incoming frame. The timestamp for telemetry is taken at send time, and there is no additional pacing loop. As a result, the NDI sender runs at whatever cadence Chromium supplies, which is ultimately controlled by the single `FramePump` timer plus Chromium’s own scheduling.【F:Video/NdiVideoPipeline.cs†L48-L87】【F:Video/NdiVideoPipeline.cs†L93-L118】
+When buffering is disabled the pipeline immediately sends each incoming frame. The timestamp for telemetry is taken at send time, and there is no additional pacing loop. As a result, the NDI sender runs at whatever cadence Chromium supplies, which is ultimately controlled by the single `FramePump` timer plus Chromium’s own scheduling.【F:Video/NdiVideoPipeline.cs†L53-L94】【F:Video/NdiVideoPipeline.cs†L100-L143】
 
 ## Pipeline behaviour with buffering enabled
 With buffering enabled the following additional steps occur:
 
-1. Every `Paint` copies the pixels into a heap-allocated `NdiVideoFrame`, stamps it with `DateTime.UtcNow`, and enqueues it in a `FrameRingBuffer` (dropping the oldest frame if the buffer is full).【F:Video/NdiVideoFrame.cs†L6-L33】【F:Video/FrameRingBuffer.cs†L4-L58】
-2. A background pacing task wakes on its own `PeriodicTimer`, which also uses the configured frame duration. On each tick it dequeues the newest buffered frame (disposing any older ones) and sends it. If the buffer is empty, it re-sends the most recently transmitted frame to hold the cadence.【F:Video/NdiVideoPipeline.cs†L62-L112】【F:Video/FrameRingBuffer.cs†L60-L85】
-3. Telemetry shows the counts of repeated frames, overflow drops, and stale drops so the operator can see how often the paced loop failed to obtain a fresh frame.【F:Video/NdiVideoPipeline.cs†L200-L234】
-
-## Why paced mode currently stutters
-The render pump and the paced output loop both run off independent `PeriodicTimer` instances that are configured with exactly the same interval (the requested frame duration) but have no phase coordination. When the pacing loop wakes before a new `Paint` has been enqueued, `DequeueLatest` returns `null`, so the pipeline repeats the previous frame to maintain cadence. That repeated frame increments the `repeated` counter seen in telemetry. Because the two timers continually drift relative to one another, this situation recurs regularly, producing the pattern of “captured slightly ahead of sent” with dozens of repeats in the supplied log (e.g., 47 repeats after ~1,400 frames).【F:Video/FramePump.cs†L21-L47】【F:Video/NdiVideoPipeline.cs†L62-L112】【F:Video/NdiVideoPipeline.cs†L139-L198】
-
-In contrast, when buffering is disabled there is only one timing source (Chromium’s paint cadence), so each frame is sent immediately after it is produced and no repeats are generated.
-
-The current design therefore trades the direct path’s minimal latency for a paced loop that repeatedly falls back to `RepeatLastFrame`. Instead of smoothing, this manifests as visible stutter because viewers receive duplicate frames at roughly the same rate that the two timers fall out of phase.
+1. Every `Paint` copies the pixels into a heap-allocated `NdiVideoFrame`, stamps it with `DateTime.UtcNow`, and enqueues it in a `FrameRingBuffer` (dropping the oldest frame if the buffer is full).【F:Video/NdiVideoFrame.cs†L6-L33】【F:Video/FrameRingBuffer.cs†L4-L70】
+2. A background pacing task wakes on its own `PeriodicTimer`, which also uses the configured frame duration. The loop waits until the buffer holds `BufferDepth` frames before it sends anything; this “priming” step establishes a fixed latency of roughly `BufferDepth / fps` before the first paced frame appears.【F:Video/NdiVideoPipeline.cs†L96-L158】
+3. Once primed, each pacing tick dequeues exactly one frame from the buffer and transmits it. If the backlog ever falls below the configured depth, the loop repeats the previously transmitted frame and re-enters warm-up, refusing to drain the queue until enough fresh frames accumulate to restore the latency bucket.【F:Video/NdiVideoPipeline.cs†L158-L200】
+4. Telemetry shows whether the buffer is currently primed, how many frames are queued, how many frames were dropped due to overflow/staleness, how often underruns occurred, and how long the last warm-up took. This makes it easy to correlate on-air stutter with buffer health.【F:Video/NdiVideoPipeline.cs†L218-L245】
 
 ## Implications
-* The paced mode can still absorb short-term spikes if Chromium briefly outruns the sender, but it does not actively smooth cadence when both sides are running at the same nominal rate.
-* Any improvement needs either tighter coordination (e.g., pacing off the capture timestamps, or waiting for a new frame before transmitting) or a decoupled pump cadence so the buffer regularly holds multiple frames when the paced loop fires.
+* Operators should expect approximately `BufferDepth / fps` of added latency when enabling the paced buffer. That delay remains constant unless the capture side falls behind, in which case the output repeats the last frame until the backlog is healthy again.
+* Because the pacing loop refuses to send partially warmed buffers, jitter in Chromium’s paint cadence is absorbed by repeating the previous frame rather than delivering new frames early. This keeps presentation cadence smooth even if it occasionally requires repeats.
+* Telemetry consumers can monitor `primed`, `backlog`, `underruns`, and `warmups` to determine whether the buffer configuration is sufficient for the rendered workload.【F:Video/NdiVideoPipeline.cs†L218-L245】
 

--- a/Tests/Tractus.HtmlToNdi.Tests/NdiVideoPipelineTests.cs
+++ b/Tests/Tractus.HtmlToNdi.Tests/NdiVideoPipelineTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Runtime.InteropServices;
 using Serilog;
 using Serilog.Core;
@@ -10,12 +11,14 @@ namespace Tractus.HtmlToNdi.Tests;
 
 public class NdiVideoPipelineTests
 {
+    private sealed record SentFrame(NDIlib.video_frame_v2_t Frame, byte FirstByte);
+
     private sealed class CollectingSender : INdiVideoSender
     {
         private readonly object gate = new();
-        private readonly List<NDIlib.video_frame_v2_t> frames = new();
+        private readonly List<SentFrame> frames = new();
 
-        public IReadOnlyList<NDIlib.video_frame_v2_t> Frames
+        public IReadOnlyList<SentFrame> Frames
         {
             get
             {
@@ -30,7 +33,13 @@ public class NdiVideoPipelineTests
         {
             lock (gate)
             {
-                frames.Add(frame);
+                byte firstByte = 0;
+                if (frame.p_data != IntPtr.Zero)
+                {
+                    firstByte = Marshal.ReadByte(frame.p_data);
+                }
+
+                frames.Add(new SentFrame(frame, firstByte));
             }
         }
     }
@@ -64,12 +73,12 @@ public class NdiVideoPipelineTests
 
         var frames = sender.Frames;
         Assert.Single(frames);
-        Assert.Equal(60, frames[0].frame_rate_N);
-        Assert.Equal(1, frames[0].frame_rate_D);
+        Assert.Equal(60, frames[0].Frame.frame_rate_N);
+        Assert.Equal(1, frames[0].Frame.frame_rate_D);
     }
 
     [Fact]
-    public async Task BufferedModeRepeatsLastFrameWhenIdle()
+    public async Task BufferedModeWaitsForConfiguredDepth()
     {
         var sender = new CollectingSender();
         var options = new NdiVideoPipelineOptions
@@ -79,27 +88,151 @@ public class NdiVideoPipelineTests
             TelemetryInterval = TimeSpan.FromDays(1)
         };
 
-        var pipeline = new NdiVideoPipeline(sender, new FrameRate(30, 1), options, CreateNullLogger());
+        using var pipeline = new NdiVideoPipeline(sender, new FrameRate(30, 1), options, CreateNullLogger());
         pipeline.Start();
 
         var size = 4 * 2 * 2;
         var buffer = Marshal.AllocHGlobal(size);
         try
         {
-            var frame = new CapturedFrame(buffer, 2, 2, 8);
-            pipeline.HandleFrame(frame);
+            FillBuffer(buffer, size, 0x11);
+            pipeline.HandleFrame(new CapturedFrame(buffer, 2, 2, 8));
+
+            await Task.Delay(200);
+            Assert.Empty(sender.Frames);
+
+            FillBuffer(buffer, size, 0x22);
+            pipeline.HandleFrame(new CapturedFrame(buffer, 2, 2, 8));
 
             await Task.Delay(200);
         }
         finally
         {
             Marshal.FreeHGlobal(buffer);
-            pipeline.Dispose();
+        }
+
+        Assert.NotEmpty(sender.Frames);
+        Assert.Equal(0x11, sender.Frames[0].FirstByte);
+        Assert.Equal(0x22, sender.Frames[1].FirstByte);
+    }
+
+    [Fact]
+    public async Task BufferedModeMaintainsFifoOrderAfterWarmup()
+    {
+        var sender = new CollectingSender();
+        var options = new NdiVideoPipelineOptions
+        {
+            EnableBuffering = true,
+            BufferDepth = 3,
+            TelemetryInterval = TimeSpan.FromDays(1)
+        };
+
+        using var pipeline = new NdiVideoPipeline(sender, new FrameRate(30, 1), options, CreateNullLogger());
+        pipeline.Start();
+
+        var size = 4 * 2 * 2;
+        var buffers = new[]
+        {
+            Marshal.AllocHGlobal(size),
+            Marshal.AllocHGlobal(size),
+            Marshal.AllocHGlobal(size),
+        };
+
+        try
+        {
+            FillBuffer(buffers[0], size, 0x31);
+            FillBuffer(buffers[1], size, 0x32);
+            FillBuffer(buffers[2], size, 0x33);
+
+            pipeline.HandleFrame(new CapturedFrame(buffers[0], 2, 2, 8));
+            pipeline.HandleFrame(new CapturedFrame(buffers[1], 2, 2, 8));
+            pipeline.HandleFrame(new CapturedFrame(buffers[2], 2, 2, 8));
+
+            await Task.Delay(400);
+        }
+        finally
+        {
+            foreach (var handle in buffers)
+            {
+                Marshal.FreeHGlobal(handle);
+            }
         }
 
         var frames = sender.Frames;
-        Assert.True(frames.Count >= 2, "Expected at least one repeat frame");
-        Assert.Equal(frames[0].p_data, frames[1].p_data);
+        Assert.True(frames.Count >= 3, "Expected all buffered frames to be sent");
+        Assert.Equal(new byte[] { 0x31, 0x32, 0x33 }, frames.Take(3).Select(f => f.FirstByte));
+    }
+
+    [Fact]
+    public async Task BufferedModeRepeatsLastFrameWhileRewarming()
+    {
+        var sender = new CollectingSender();
+        var options = new NdiVideoPipelineOptions
+        {
+            EnableBuffering = true,
+            BufferDepth = 2,
+            TelemetryInterval = TimeSpan.FromDays(1)
+        };
+
+        using var pipeline = new NdiVideoPipeline(sender, new FrameRate(30, 1), options, CreateNullLogger());
+        pipeline.Start();
+
+        var size = 4 * 2 * 2;
+        var first = Marshal.AllocHGlobal(size);
+        var second = Marshal.AllocHGlobal(size);
+        var third = Marshal.AllocHGlobal(size);
+
+        try
+        {
+            FillBuffer(first, size, 0x41);
+            FillBuffer(second, size, 0x42);
+            FillBuffer(third, size, 0x43);
+
+            pipeline.HandleFrame(new CapturedFrame(first, 2, 2, 8));
+            pipeline.HandleFrame(new CapturedFrame(second, 2, 2, 8));
+
+            await Task.Delay(250);
+
+            var framesAfterWarmup = sender.Frames.Count;
+            Assert.True(framesAfterWarmup >= 2, "Pipeline should have sent the priming frames");
+
+            // Stop feeding the pipeline so it must repeat the last frame.
+            await Task.Delay(150);
+
+            var framesBeforeNewData = sender.Frames.Count;
+            Assert.True(framesBeforeNewData > framesAfterWarmup, "Pipeline should repeat last frame during underrun");
+            Assert.Equal(sender.Frames[^2].FirstByte, sender.Frames[^1].FirstByte);
+
+            // Provide frames one at a time; nothing should be sent until the backlog refills.
+            pipeline.HandleFrame(new CapturedFrame(third, 2, 2, 8));
+
+            await Task.Delay(150);
+            var afterSingleFrame = sender.Frames.Count;
+            Assert.Equal(framesBeforeNewData, afterSingleFrame);
+
+            // Supply a second frame to satisfy the buffer depth.
+            pipeline.HandleFrame(new CapturedFrame(first, 2, 2, 8));
+
+            await Task.Delay(250);
+
+            var tail = sender.Frames.TakeLast(2).Select(f => f.FirstByte).ToArray();
+            Assert.Contains((byte)0x43, tail);
+            Assert.Contains((byte)0x41, tail);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(first);
+            Marshal.FreeHGlobal(second);
+            Marshal.FreeHGlobal(third);
+        }
+    }
+
+    private static void FillBuffer(IntPtr buffer, int size, byte value)
+    {
+        for (var i = 0; i < size; i++)
+        {
+            Marshal.WriteByte(buffer, i, value);
+        }
     }
 }
 

--- a/Video/FrameRingBuffer.cs
+++ b/Video/FrameRingBuffer.cs
@@ -54,6 +54,30 @@ internal sealed class FrameRingBuffer<T>
         }
     }
 
+    public bool TryDequeue(out T? frame)
+    {
+        lock (frames)
+        {
+            if (frames.Count == 0)
+            {
+                frame = null;
+                return false;
+            }
+
+            frame = frames.Dequeue();
+            if (overflowSinceLastDequeue > 0)
+            {
+                overflowSinceLastDequeue--;
+            }
+            else
+            {
+                overflowSinceLastDequeue = 0;
+            }
+
+            return true;
+        }
+    }
+
     public T? DequeueLatest()
     {
         lock (frames)


### PR DESCRIPTION
## Summary
- rework the paced NDI pipeline to warm up to full depth, repeat the last frame on underruns, and log priming telemetry
- add a FIFO dequeue helper to the frame ring buffer for paced draining
- document the revised buffering behaviour and cover it with pacing unit tests

## Testing
- `dotnet test` *(fails: dotnet is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b8564c0c8329971a693ecfe19b22