### PR TITLE
Improve paced buffer warm-up and telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This document is the ground-truth orientation guide. Treat it as a living spec‚Ä
 
 * Entry point: `Program.Main` (`Program.cs`). It sets the working directory, initializes logging via `AppManagement.Initialize`, parses CLI flags (including `--fps`, buffering, and telemetry settings), allocates the NDI sender up front, constructs an `NdiVideoPipeline`, then starts CefSharp OffScreen inside a dedicated synchronization context. After the browser bootstraps the app spins up the ASP.NET Core minimal API.
 * Chromium lifecycle: `AsyncContext.Run` + `SingleThreadSynchronizationContext` keep CefSharp happy on one STA-like thread. `CefWrapper.InitializeWrapperAsync` waits for the first page load, unmutes audio (CEF starts muted), subscribes to the `Paint` event, and starts a `FramePump` that invalidates Chromium at the requested cadence while a watchdog keeps the UI thread alive.
-* Video path: `ChromiumWebBrowser.Paint` forwards frames to the `NdiVideoPipeline`. In zero-copy mode the pipeline sends the GPU buffer directly; when buffering is enabled it copies into a pooled ring buffer that a paced loop drains while repeating the latest frame on underruns. Frame-rate metadata is advertised using either the configured target cadence or the measured average.
+* Video path: `ChromiumWebBrowser.Paint` forwards frames to the `NdiVideoPipeline`. In zero-copy mode the pipeline sends the GPU buffer directly; when buffering is enabled it copies into a pooled ring buffer, waits until `BufferDepth` frames are queued, then drains the backlog FIFO while repeating the latest frame on underruns so cadence stays constant. Frame-rate metadata is advertised using either the configured target cadence or the measured average.
 * Audio path: `CustomAudioHandler` exposes Cef audio, allocates a float buffer sized for one second, copies each planar channel into contiguous blocks inside that buffer, and sends it with `NDIlib.send_send_audio_v2`. (Note: the code claims ‚Äúinterleaved‚Äù but still stores channels sequentially; downstream receivers must cope with planar-like layout.)
 * Control plane: ASP.NET Core minimal API listens on HTTP (no TLS, no auth). Swagger UI is enabled. All endpoints directly call methods on the static `Program.browserWrapper` instance.
 * KVM metadata: the app advertises `<ndi_capabilities ntk_kvm="true" />` and starts a background thread that polls `NDIlib.send_capture` every second. It interprets `<ndi_kvm ...>` metadata frames, caching normalized mouse coordinates on opcode `0x03` and triggering a left click on opcode `0x04`.
@@ -31,8 +31,8 @@ This document is the ground-truth orientation guide. Treat it as a living spec‚Ä
 | `--w=<int>` | `--w=1920` | Sets browser width in pixels. Defaults to 1920. |
 | `--h=<int>` | `--h=1080` | Sets browser height in pixels. Defaults to 1080. |
 | `--fps=<double|fraction>` | `--fps=59.94` | Target NDI frame cadence. Accepts decimal or rational values (e.g. `60000/1001`). Defaults to 60 fps. |
-| `--buffer-depth=<int>` | `--buffer-depth=3` | Enables the paced output buffer with the specified capacity. `0` keeps the legacy zero-copy mode. |
-| `--enable-output-buffer` | `--enable-output-buffer` | Convenience flag to enable paced buffering with the default depth (3 frames). |
+| `--buffer-depth=<int>` | `--buffer-depth=3` | Enables the paced output buffer with the specified capacity. When enabled the sender waits for `depth` frames before transmitting, adding roughly `depth / fps` seconds of intentional latency. `0` keeps the legacy zero-copy mode. |
+| `--enable-output-buffer` | `--enable-output-buffer` | Convenience flag to enable paced buffering with the default depth (3 frames, ‚âà`3 / fps` seconds of latency once primed). |
 | `--telemetry-interval=<seconds>` | `--telemetry-interval=10` | Seconds between video pipeline telemetry log entries. Defaults to 10. |
 | `--windowless-frame-rate=<double>` | `--windowless-frame-rate=60` | Overrides Chromium's internal repaint cadence. Defaults to the rounded value of `--fps`. |
 | `--disable-gpu-vsync` | `--disable-gpu-vsync` | Passes `--disable-gpu-vsync` to Chromium to remove GPU vsync throttling. |
@@ -151,7 +151,7 @@ When adding routes, update **both** this table and `Tractus.HtmlToNdi.http` samp
 
 ### Frame buffering (`Video/FrameRingBuffer.cs`)
 * `FrameRingBuffer<T>` drops the oldest frame when capacity is exceeded and surfaces it via the `out` parameter. That action increments `DroppedFromOverflow` but does **not** dispose the frame; the caller must do so.
-* When the paced loop calls `DequeueLatest`, the buffer disposes older frames before returning the newest. To keep telemetry accurate, it only increments `DroppedAsStale` for frames not already counted as overflow since the previous dequeue, avoiding double-counting when producers outrun the consumer briefly.
+* `TryDequeue` returns the oldest frame without disturbing the rest of the queue so the paced sender can preserve FIFO ordering. `DequeueLatest` remains available for scenarios that only care about the newest frame; it disposes older entries before returning the most recent one and avoids double-counting stale drops when overflow was already recorded.
 
 ### Logging & diagnostics (`AppManagement.cs`)
 * `AppManagement.InstanceName` composes `<os>_<arch>_<machinename>` for telemetry or metadata (not currently used elsewhere).

--- a/Docs/paced-output-buffer.md
+++ b/Docs/paced-output-buffer.md
@@ -1,31 +1,28 @@
 # Paced output buffer behaviour
 
 ## Summary
-This note explains how the video pipeline behaves when the paced output buffer is enabled versus disabled, and why the paced mode currently introduces visible stutter even though it is meant to smooth the stream.
+This note explains how the video pipeline behaves when the paced output buffer is enabled versus disabled. When pacing is active the pipeline queues captured frames until the backlog reaches the configured depth, then drains one frame per timer tick. That “bucket” introduces a predictable latency of roughly `BufferDepth / fps` seconds while ensuring the NDI sender presents frames at an even cadence. If the queue dips below the target depth the sender repeats the last frame and re-warms before transmitting fresh video again.
 
 ## What drives Chromium renders
-Chromium repaints are driven by `FramePump`. The pump wakes on a `PeriodicTimer` whose interval is derived from the configured frame rate, calls `Invalidate` on the browser host, and relies on CefSharp to raise `Paint` callbacks afterwards. A watchdog issues an extra invalidate if paints stop arriving for more than a second.【F:Video/FramePump.cs†L21-L74】
+Chromium repaints are driven by `FramePump`. The pump wakes on a `PeriodicTimer` whose interval is derived from the configured frame rate, calls `Invalidate` on the browser host, and relies on CefSharp to raise `Paint` callbacks afterwards. A watchdog issues an extra invalidate if paints stop arriving for more than a second.【F:Video/FramePump.cs†L7-L115】
 
-Each `Paint` event is forwarded to `NdiVideoPipeline.HandleFrame`, which wraps the buffer and hands it to the pipeline.【F:Chromium/CefWrapper.cs†L48-L82】
+Each `Paint` event is forwarded to `NdiVideoPipeline.HandleFrame`, which wraps the buffer and hands it to the pipeline.【F:Chromium/CefWrapper.cs†L43-L123】
 
 ## Pipeline behaviour without buffering
-When buffering is disabled the pipeline immediately sends each incoming frame. The timestamp for telemetry is taken at send time, and there is no additional pacing loop. As a result, the NDI sender runs at whatever cadence Chromium supplies, which is ultimately controlled by the single `FramePump` timer plus Chromium’s own scheduling.【F:Video/NdiVideoPipeline.cs†L48-L87】【F:Video/NdiVideoPipeline.cs†L93-L118】
+When buffering is disabled the pipeline immediately sends each incoming frame. The timestamp for telemetry is taken at send time, and there is no additional pacing loop. As a result, the NDI sender runs at whatever cadence Chromium supplies, which is ultimately controlled by the single `FramePump` timer plus Chromium’s own scheduling.【F:Video/NdiVideoPipeline.cs†L43-L114】
 
 ## Pipeline behaviour with buffering enabled
 With buffering enabled the following additional steps occur:
 
-1. Every `Paint` copies the pixels into a heap-allocated `NdiVideoFrame`, stamps it with `DateTime.UtcNow`, and enqueues it in a `FrameRingBuffer` (dropping the oldest frame if the buffer is full).【F:Video/NdiVideoFrame.cs†L6-L33】【F:Video/FrameRingBuffer.cs†L4-L58】
-2. A background pacing task wakes on its own `PeriodicTimer`, which also uses the configured frame duration. On each tick it dequeues the newest buffered frame (disposing any older ones) and sends it. If the buffer is empty, it re-sends the most recently transmitted frame to hold the cadence.【F:Video/NdiVideoPipeline.cs†L62-L112】【F:Video/FrameRingBuffer.cs†L60-L85】
-3. Telemetry shows the counts of repeated frames, overflow drops, and stale drops so the operator can see how often the paced loop failed to obtain a fresh frame.【F:Video/NdiVideoPipeline.cs†L200-L234】
+1. Every `Paint` copies the pixels into a heap-allocated `NdiVideoFrame`, stamps it with `DateTime.UtcNow`, and enqueues it in a `FrameRingBuffer` (dropping the oldest frame if the bucket is full).【F:Video/NdiVideoFrame.cs†L6-L34】【F:Video/FrameRingBuffer.cs†L5-L77】
+2. The pacing task wakes on its own `PeriodicTimer`. While the bucket is filling it does not transmit new frames; once the backlog reaches `BufferDepth` it marks the buffer as primed and sends one frame per tick in FIFO order.【F:Video/NdiVideoPipeline.cs†L116-L181】
+3. If the backlog stays below the requested depth for consecutive ticks or the queue is empty, the sender repeats the most recently transmitted frame, increments an underrun counter, and re-enters warm-up until enough fresh frames arrive to restore the desired latency.【F:Video/NdiVideoPipeline.cs†L118-L181】
+4. Telemetry now surfaces the primed state, live backlog, overflow/stale drops, underruns, warm-up cycles, and the duration of the most recent warm-up so operators can see how healthy the buffer is at a glance.【F:Video/NdiVideoPipeline.cs†L218-L241】
 
-## Why paced mode currently stutters
-The render pump and the paced output loop both run off independent `PeriodicTimer` instances that are configured with exactly the same interval (the requested frame duration) but have no phase coordination. When the pacing loop wakes before a new `Paint` has been enqueued, `DequeueLatest` returns `null`, so the pipeline repeats the previous frame to maintain cadence. That repeated frame increments the `repeated` counter seen in telemetry. Because the two timers continually drift relative to one another, this situation recurs regularly, producing the pattern of “captured slightly ahead of sent” with dozens of repeats in the supplied log (e.g., 47 repeats after ~1,400 frames).【F:Video/FramePump.cs†L21-L47】【F:Video/NdiVideoPipeline.cs†L62-L112】【F:Video/NdiVideoPipeline.cs†L139-L198】
-
-In contrast, when buffering is disabled there is only one timing source (Chromium’s paint cadence), so each frame is sent immediately after it is produced and no repeats are generated.
-
-The current design therefore trades the direct path’s minimal latency for a paced loop that repeatedly falls back to `RepeatLastFrame`. Instead of smoothing, this manifests as visible stutter because viewers receive duplicate frames at roughly the same rate that the two timers fall out of phase.
+## Latency expectations
+Enabling the paced buffer intentionally lags capture by `BufferDepth / fps` seconds. That latency appears when the application starts and after every underrun because the sender waits for the queue to refill before resuming normal transmission. During those warm-up periods the pipeline keeps the NDI cadence steady by repeating the last frame, so downstream receivers never lose the clock even though no fresh video is available.【F:Video/NdiVideoPipeline.cs†L116-L181】
 
 ## Implications
-* The paced mode can still absorb short-term spikes if Chromium briefly outruns the sender, but it does not actively smooth cadence when both sides are running at the same nominal rate.
-* Any improvement needs either tighter coordination (e.g., pacing off the capture timestamps, or waiting for a new frame before transmitting) or a decoupled pump cadence so the buffer regularly holds multiple frames when the paced loop fires.
-
+* Enabling pacing is a conscious trade-off: operators should size `BufferDepth` to balance acceptable latency against resilience to jitter.【F:Video/NdiVideoPipeline.cs†L116-L181】
+* Telemetry consumers should look for `primed`, `buffered`, `underruns`, `warmups`, and `lastWarmupMs` in the log output to understand how the buffer is behaving.【F:Video/NdiVideoPipeline.cs†L218-L241】
+* When buffering is disabled the legacy direct path remains untouched—frames are forwarded immediately with effectively zero additional latency.【F:Video/NdiVideoPipeline.cs†L43-L114】

--- a/README.md
+++ b/README.md
@@ -24,14 +24,16 @@ Parameter|Description
 `--port=9999`|The port the HTTP server will listen on. Defaults to `9999`.
 `--url="https://www.tractus.ca"`|The startup webpage. Defaults to `https://testpattern.tractusevents.com/`.
 `--fps=59.94`|Target NDI frame rate. Accepts integer, decimal or rational values (e.g. `60000/1001`). Defaults to `60`.
-`--buffer-depth=3`|Enable the paced output buffer with the specified frame capacity. Set to `0` (default) to run zero-copy.
-`--enable-output-buffer`|Shortcut to turn on paced buffering with the default depth of 3 frames.
+`--buffer-depth=3`|Enable the paced output buffer with the specified frame capacity. When enabled the sender waits for the queue to hold `depth` frames before transmitting, adding roughly `depth / fps` seconds of intentional latency. Set to `0` (default) to run zero-copy.
+`--enable-output-buffer`|Shortcut to turn on paced buffering with the default depth of 3 frames (≈`3 / fps` seconds of latency once primed).
 `--telemetry-interval=10`|Seconds between video pipeline telemetry log entries. Defaults to 10 seconds.
 `--windowless-frame-rate=60`|Overrides CEF's internal repaint cadence. Defaults to the nearest integer of `--fps`.
 `--disable-gpu-vsync`|Disables Chromium's GPU vsync throttling.
 `--disable-frame-rate-limit`|Disables Chromium's frame rate limiter.
 `--launcher`|Forces the launcher window to appear even when other parameters are supplied.
 `--no-launcher`|Skips the launcher and honours the supplied command-line arguments only.
+
+When the paced buffer is enabled the pipeline repeats the most recently transmitted frame while warming up or recovering from an underrun so receivers continue to see a stable cadence. See [`Docs/paced-output-buffer.md`](Docs/paced-output-buffer.md) for a deeper walkthrough of the priming and telemetry behaviour.
 
 #### Example Launch
 

--- a/Tests/Tractus.HtmlToNdi.Tests/FrameRingBufferTests.cs
+++ b/Tests/Tractus.HtmlToNdi.Tests/FrameRingBufferTests.cs
@@ -58,4 +58,36 @@ public class FrameRingBufferTests
         Assert.True(second.Disposed);
         Assert.Equal(2, buffer.DroppedAsStale);
     }
+
+    [Fact]
+    public void TryDequeueReturnsOldestWithoutDisposal()
+    {
+        var buffer = new FrameRingBuffer<DisposableStub>(3);
+        var first = new DisposableStub();
+        var second = new DisposableStub();
+
+        buffer.Enqueue(first, out _);
+        buffer.Enqueue(second, out _);
+
+        var successFirst = buffer.TryDequeue(out var dequeuedFirst);
+        Assert.True(successFirst);
+        Assert.Same(first, dequeuedFirst);
+        Assert.False(first.Disposed);
+
+        var successSecond = buffer.TryDequeue(out var dequeuedSecond);
+        Assert.True(successSecond);
+        Assert.Same(second, dequeuedSecond);
+        Assert.False(second.Disposed);
+    }
+
+    [Fact]
+    public void TryDequeueReturnsFalseWhenEmpty()
+    {
+        var buffer = new FrameRingBuffer<DisposableStub>(2);
+
+        var success = buffer.TryDequeue(out var dequeued);
+
+        Assert.False(success);
+        Assert.Null(dequeued);
+    }
 }

--- a/Tests/Tractus.HtmlToNdi.Tests/NdiVideoPipelineTests.cs
+++ b/Tests/Tractus.HtmlToNdi.Tests/NdiVideoPipelineTests.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Serilog;
 using Serilog.Core;
 using Tractus.HtmlToNdi.Video;
@@ -10,12 +12,14 @@ namespace Tractus.HtmlToNdi.Tests;
 
 public class NdiVideoPipelineTests
 {
+    private sealed record SentFrame(NDIlib.video_frame_v2_t Frame, byte[] Payload);
+
     private sealed class CollectingSender : INdiVideoSender
     {
         private readonly object gate = new();
-        private readonly List<NDIlib.video_frame_v2_t> frames = new();
+        private readonly List<SentFrame> frames = new();
 
-        public IReadOnlyList<NDIlib.video_frame_v2_t> Frames
+        public IReadOnlyList<SentFrame> Frames
         {
             get
             {
@@ -30,7 +34,14 @@ public class NdiVideoPipelineTests
         {
             lock (gate)
             {
-                frames.Add(frame);
+                var size = frame.yres * frame.line_stride_in_bytes;
+                var payload = new byte[size];
+                if (size > 0 && frame.p_data != IntPtr.Zero)
+                {
+                    Marshal.Copy(frame.p_data, payload, 0, size);
+                }
+
+                frames.Add(new SentFrame(frame, payload));
             }
         }
     }
@@ -64,8 +75,58 @@ public class NdiVideoPipelineTests
 
         var frames = sender.Frames;
         Assert.Single(frames);
-        Assert.Equal(60, frames[0].frame_rate_N);
-        Assert.Equal(1, frames[0].frame_rate_D);
+        Assert.Equal(60, frames[0].Frame.frame_rate_N);
+        Assert.Equal(1, frames[0].Frame.frame_rate_D);
+    }
+
+    [Fact]
+    public async Task BufferedModeWaitsForWarmupBeforeSending()
+    {
+        var sender = new CollectingSender();
+        var options = new NdiVideoPipelineOptions
+        {
+            EnableBuffering = true,
+            BufferDepth = 3,
+            TelemetryInterval = TimeSpan.FromDays(1)
+        };
+
+        var pipeline = new NdiVideoPipeline(sender, new FrameRate(30, 1), options, CreateNullLogger());
+        pipeline.Start();
+
+        var frameSize = 4 * 2 * 2;
+        var buffers = new IntPtr[3];
+        try
+        {
+            await Task.Delay(150);
+            Assert.Empty(sender.Frames);
+
+            for (var i = 0; i < buffers.Length; i++)
+            {
+                buffers[i] = Marshal.AllocHGlobal(frameSize);
+                FillBuffer(buffers[i], frameSize, (byte)(0x10 + i));
+                pipeline.HandleFrame(new CapturedFrame(buffers[i], 2, 2, 8));
+            }
+
+            var warmed = SpinWait.SpinUntil(() => sender.Frames.Count >= buffers.Length, TimeSpan.FromMilliseconds(600));
+            Assert.True(warmed);
+            Assert.True(pipeline.BufferPrimed);
+
+            var frames = sender.Frames.Take(buffers.Length).ToArray();
+            Assert.Equal(0x10, frames[0].Payload[0]);
+            Assert.Equal(0x11, frames[1].Payload[0]);
+            Assert.Equal(0x12, frames[2].Payload[0]);
+        }
+        finally
+        {
+            pipeline.Dispose();
+            foreach (var ptr in buffers)
+            {
+                if (ptr != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(ptr);
+                }
+            }
+        }
     }
 
     [Fact]
@@ -82,24 +143,104 @@ public class NdiVideoPipelineTests
         var pipeline = new NdiVideoPipeline(sender, new FrameRate(30, 1), options, CreateNullLogger());
         pipeline.Start();
 
-        var size = 4 * 2 * 2;
-        var buffer = Marshal.AllocHGlobal(size);
+        var frameSize = 4 * 2 * 2;
+        var buffers = new IntPtr[2];
         try
         {
-            var frame = new CapturedFrame(buffer, 2, 2, 8);
-            pipeline.HandleFrame(frame);
+            buffers[0] = Marshal.AllocHGlobal(frameSize);
+            buffers[1] = Marshal.AllocHGlobal(frameSize);
+            FillBuffer(buffers[0], frameSize, 0x20);
+            FillBuffer(buffers[1], frameSize, 0x30);
 
-            await Task.Delay(200);
+            pipeline.HandleFrame(new CapturedFrame(buffers[0], 2, 2, 8));
+            pipeline.HandleFrame(new CapturedFrame(buffers[1], 2, 2, 8));
+
+            var primed = SpinWait.SpinUntil(() => sender.Frames.Count >= 2, TimeSpan.FromMilliseconds(500));
+            Assert.True(primed);
+
+            await Task.Delay(400);
+
+            var frames = sender.Frames;
+            Assert.True(frames.Count >= 4, "Expected repeated frames while idle");
+            var last = frames[^1];
+            var previous = frames[^2];
+            Assert.Equal(previous.Frame.p_data, last.Frame.p_data);
+            Assert.Equal(previous.Payload[0], last.Payload[0]);
         }
         finally
         {
-            Marshal.FreeHGlobal(buffer);
             pipeline.Dispose();
+            foreach (var ptr in buffers)
+            {
+                if (ptr != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(ptr);
+                }
+            }
         }
+    }
 
-        var frames = sender.Frames;
-        Assert.True(frames.Count >= 2, "Expected at least one repeat frame");
-        Assert.Equal(frames[0].p_data, frames[1].p_data);
+    [Fact]
+    public async Task BufferedModeRewarmsAfterUnderrun()
+    {
+        var sender = new CollectingSender();
+        var options = new NdiVideoPipelineOptions
+        {
+            EnableBuffering = true,
+            BufferDepth = 2,
+            TelemetryInterval = TimeSpan.FromDays(1)
+        };
+
+        var pipeline = new NdiVideoPipeline(sender, new FrameRate(30, 1), options, CreateNullLogger());
+        pipeline.Start();
+
+        var frameSize = 4 * 2 * 2;
+        var buffers = new IntPtr[4];
+        try
+        {
+            for (var i = 0; i < 2; i++)
+            {
+                buffers[i] = Marshal.AllocHGlobal(frameSize);
+                FillBuffer(buffers[i], frameSize, (byte)(0x40 + i));
+                pipeline.HandleFrame(new CapturedFrame(buffers[i], 2, 2, 8));
+            }
+
+            var primed = SpinWait.SpinUntil(() => pipeline.BufferPrimed && sender.Frames.Count >= 2, TimeSpan.FromMilliseconds(500));
+            Assert.True(primed);
+
+            await Task.Delay(250);
+            Assert.True(pipeline.BufferUnderruns >= 1);
+            Assert.False(pipeline.BufferPrimed);
+
+            for (var i = 2; i < buffers.Length; i++)
+            {
+                buffers[i] = Marshal.AllocHGlobal(frameSize);
+                FillBuffer(buffers[i], frameSize, (byte)(0x60 + i));
+                pipeline.HandleFrame(new CapturedFrame(buffers[i], 2, 2, 8));
+            }
+
+            var rearmed = SpinWait.SpinUntil(() => pipeline.BufferPrimed && sender.Frames.Any(f => f.Payload[0] == 0x63), TimeSpan.FromMilliseconds(800));
+            Assert.True(rearmed);
+            Assert.True(pipeline.LastWarmupDuration > TimeSpan.Zero);
+        }
+        finally
+        {
+            pipeline.Dispose();
+            foreach (var ptr in buffers)
+            {
+                if (ptr != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(ptr);
+                }
+            }
+        }
+    }
+
+    private static void FillBuffer(IntPtr buffer, int size, byte value)
+    {
+        var data = new byte[size];
+        Array.Fill(data, value);
+        Marshal.Copy(data, 0, buffer, size);
     }
 }
 

--- a/Video/FrameRingBuffer.cs
+++ b/Video/FrameRingBuffer.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Tractus.HtmlToNdi.Video;
 
 internal sealed class FrameRingBuffer<T>
@@ -51,6 +53,26 @@ internal sealed class FrameRingBuffer<T>
             }
 
             frames.Enqueue(frame);
+        }
+    }
+
+    public bool TryDequeue([NotNullWhen(true)] out T? frame)
+    {
+        lock (frames)
+        {
+            if (frames.Count == 0)
+            {
+                frame = null;
+                return false;
+            }
+
+            frame = frames.Dequeue();
+            if (overflowSinceLastDequeue > 0)
+            {
+                overflowSinceLastDequeue--;
+            }
+
+            return true;
         }
     }
 


### PR DESCRIPTION
## Summary
- warm up the paced pipeline to the configured depth, repeat frames during underruns, and expose underrun telemetry
- add FIFO dequeue support to the frame ring buffer with new unit tests covering warm-up and recovery cases
- document the intentional latency trade-offs for `--buffer-depth` in the README and paced buffer guide

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b8564c0c8329971a693ecfe19b22