### PR TITLE
Implement integrator-based paced buffer recovery

### DIFF
--- a/Video/NdiVideoPipeline.cs
+++ b/Video/NdiVideoPipeline.cs
@@ -306,6 +306,7 @@ internal sealed class NdiVideoPipeline : IDisposable
         warmup = true;
         warmupRepeatTicks = 0;
         warmupStarted = DateTime.UtcNow;
+        latencyError = Math.Max(latencyError, -targetDepth);
 
         if (lowWatermarkTriggered)
         {

--- a/Video/NdiVideoPipeline.cs
+++ b/Video/NdiVideoPipeline.cs
@@ -158,6 +158,10 @@ internal sealed class NdiVideoPipeline : IDisposable
 
         var backlog = ringBuffer.Count;
         latencyError += backlog - targetDepth;
+        if (latencyError < -targetDepth)
+        {
+            latencyError = -targetDepth;
+        }
 
         if (lastSentFrame is not null)
         {


### PR DESCRIPTION
## Summary
- rework the paced NDI video pipeline to enforce fixed latency using a hysteresis integrator, high/low watermarks, and warm-up tracking
- add frame ring buffer helpers for trimming to the latest capture and marking stale drops to support the new pacer
- extend the test suite with coverage for warm-up recovery, latency guarding, and overflow trimming behaviour

## Testing
- `dotnet test` *(fails: dotnet CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5eac932c08329a9ecfcef19b1c523