### PR TITLE
Add paced invalidation, capture backpressure, and pump cadence alignment toggles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ For the current paced-buffer design direction and recommendations, review `Docs/
 ## 1. What the current build actually does (net8.0, December 2024 snapshot)
 
 * Entry point: `Program.Main` (`Program.cs`). It sets the working directory, initializes logging via `AppManagement.Initialize`, parses CLI flags (including `--fps`, buffering, and telemetry settings), allocates the NDI sender up front, constructs an `NdiVideoPipeline`, then starts CefSharp OffScreen inside a dedicated synchronization context. After the browser bootstraps the app spins up the ASP.NET Core minimal API.
-* Chromium lifecycle: `AsyncContext.Run` + `SingleThreadSynchronizationContext` keep CefSharp happy on one STA-like thread. `CefWrapper.InitializeWrapperAsync` waits for the first page load, unmutes audio (CEF starts muted), subscribes to the `Paint` event, and starts a `FramePump` that invalidates Chromium at the requested cadence while a watchdog keeps the UI thread alive.
-* Video path: `ChromiumWebBrowser.Paint` forwards frames to the `NdiVideoPipeline`. In zero-copy mode the pipeline sends the GPU buffer directly; when buffering is enabled it copies into a pooled ring buffer, waits until `BufferDepth` frames are queued, then drains the backlog FIFO while repeating the latest frame on underruns so cadence stays constant. Frame-rate metadata is advertised using either the configured target cadence or the measured average.
+* Chromium lifecycle: `AsyncContext.Run` + `SingleThreadSynchronizationContext` keep CefSharp happy on one STA-like thread. `CefWrapper.InitializeWrapperAsync` waits for the first page load, unmutes audio (CEF starts muted), subscribes to the `Paint` event, and starts a `FramePump` invalidator. The pump can now run in periodic mode or accept paced triggers from the video pipeline, applying capture backpressure pauses and cadence-alignment adjustments supplied by telemetry while a watchdog keeps the UI thread alive.
+* Video path: `ChromiumWebBrowser.Paint` forwards frames to the `NdiVideoPipeline`. In zero-copy mode the pipeline sends the GPU buffer directly; when buffering is enabled it copies into a pooled ring buffer, waits until `BufferDepth` frames are queued, then drains the backlog FIFO while repeating the latest frame on underruns so cadence stays constant. Optional latency expansion continues draining queued frames during recovery. When paced invalidation is enabled the pipeline only requests new captures when it is ready and can temporarily pause Chromium after sustained oversupply. Frame-rate metadata is advertised using either the configured target cadence or the measured average.
 * Audio path: `CustomAudioHandler` exposes Cef audio, allocates a float buffer sized for one second, copies each planar channel into contiguous blocks inside that buffer, and sends it with `NDIlib.send_send_audio_v2`. (Note: the code claims “interleaved” but still stores channels sequentially; downstream receivers must cope with planar-like layout.)
 * Control plane: ASP.NET Core minimal API listens on HTTP (no TLS, no auth). Swagger UI is enabled. All endpoints directly call methods on the static `Program.browserWrapper` instance.
 * KVM metadata: the app advertises `<ndi_capabilities ntk_kvm="true" />` and starts a background thread that polls `NDIlib.send_capture` every second. It interprets `<ndi_kvm ...>` metadata frames, caching normalized mouse coordinates on opcode `0x03` and triggering a left click on opcode `0x04`.
@@ -35,6 +35,12 @@ For the current paced-buffer design direction and recommendations, review `Docs/
 | `--fps=<double|fraction>` | `--fps=59.94` | Target NDI frame cadence. Accepts decimal or rational values (e.g. `60000/1001`). Defaults to 60 fps. |
 | `--buffer-depth=<int>` | `--buffer-depth=3` | Enables the paced output buffer with the specified capacity. When enabled the sender waits for `depth` frames before transmitting, adding roughly `depth / fps` seconds of intentional latency. `0` keeps the legacy zero-copy mode. |
 | `--enable-output-buffer` | `--enable-output-buffer` | Convenience flag to enable paced buffering with the default depth (3 frames, ≈`3 / fps` seconds of latency once primed). |
+| `--allow-latency-expansion` | `--allow-latency-expansion` | Keeps draining any buffered frames during recovery instead of immediately repeating the last capture, trading temporary extra latency for smoother catch-up motion. |
+| `--enable-paced-invalidation` | `--enable-paced-invalidation` | Drives Chromium invalidations directly from the paced sender so captures only occur when the pipeline is ready. Falls back to the legacy periodic invalidator when omitted. |
+| `--enable-capture-backpressure` | `--enable-capture-backpressure` | Pauses Chromium invalidations after sustained positive latency or a deep backlog so oversupply does not grow unchecked. Automatically resumes once latency and backlog settle. |
+| `--enable-pump-cadence-alignment` | `--enable-pump-cadence-alignment` | Allows cadence drift measurements from the paced pipeline to influence the frame pump’s periodic cadence as well as the paced sender. |
+| `--disable-capture-alignment` | `--disable-capture-alignment` | Disables paced output alignment that normally nudges send times using capture timestamps. `--align-with-capture-timestamps` explicitly re-enables the behaviour. |
+| `--disable-cadence-telemetry` | `--disable-cadence-telemetry` | Suppresses capture/output cadence jitter metrics in telemetry logs. `--enable-cadence-telemetry` re-enables them for targeted runs. |
 | `--telemetry-interval=<seconds>` | `--telemetry-interval=10` | Seconds between video pipeline telemetry log entries. Defaults to 10. |
 | `--windowless-frame-rate=<double>` | `--windowless-frame-rate=60` | Overrides Chromium's internal repaint cadence. Defaults to the rounded value of `--fps`. |
 | `--disable-gpu-vsync` | `--disable-gpu-vsync` | Passes `--disable-gpu-vsync` to Chromium to remove GPU vsync throttling. |
@@ -61,7 +67,8 @@ Other configuration surfaces:
   SingleThreadSynchronizationContext.cs # BlockingCollection-backed synchronization context
 /Video/
   CapturedFrame.cs                    # Lightweight struct describing pixels passed from Chromium to the pipeline
-  FramePump.cs                        # Periodic Chromium invalidator with watchdog
+  FramePump.cs                        # Chromium invalidator supporting periodic + paced modes with watchdog and pause support
+  IChromiumInvalidator.cs             # Abstraction for invalidators so the pipeline can coordinate cadence/backpressure
   FrameRate.cs                        # Frame-rate parsing helpers (decimal/fraction) and metadata conversion
   FrameRingBuffer.cs                  # Drop-oldest ring buffer used by the paced pipeline
   FrameTimeAverager.cs                # Sliding-window FPS estimator for telemetry metadata
@@ -134,7 +141,7 @@ When adding routes, update **both** this table and `Tractus.HtmlToNdi.http` samp
 
 ### CefWrapper (`Chromium/CefWrapper.cs`)
 * `ChromiumWebBrowser` is constructed with `AudioHandler = new CustomAudioHandler()` and a fixed `System.Drawing.Size(width,height)`.
-* A `FramePump` invalidates Chromium on the cadence derived from `--fps` (or `--windowless-frame-rate`) and contains a watchdog to recover if paint events stall.
+* A `FramePump` invalidates Chromium on the cadence derived from `--fps` (or `--windowless-frame-rate`) and contains a watchdog to recover if paint events stall. When paced invalidation is enabled it waits for the video pipeline to request the next invalidate and honours pause/resume calls triggered by capture backpressure.
 * `ScrollBy` always uses `(x=0,y=0)` as the mouse location; complex scrolling (e.g., inside scrolled divs) may require additional API work.
 * `Click` only supports the left mouse button; drag, double-click, or right-click interactions are not implemented.
 * `SendKeystrokes` issues **only** `KeyDown` events with `NativeKeyCode=Convert.ToInt32(char)`. There is no key-up, modifiers, or IME support—uppercase letters require the page to handle them despite missing Shift state.
@@ -205,4 +212,10 @@ When adding routes, update **both** this table and `Tractus.HtmlToNdi.http` samp
 
 ---
 
+### NdiVideoPipeline (`Video/NdiVideoPipeline.cs`)
+* Supports zero-copy and paced-buffer modes. In paced mode the pipeline primes a ring buffer, optionally expands latency during recovery, and exposes telemetry on backlog/cadence.
+* When paced invalidation is enabled the pipeline requests invalidations only when it is ready to consume the next frame, applies sustained-latency gating before pausing Chromium, and resumes once backlog/latency stabilise.
+* Cadence drift reported by telemetry can adjust both the paced sender’s schedule and (when configured) the frame pump’s periodic interval.
+
 _Last reviewed against repository state in this workspace. Update sections promptly when behaviour changes._
+

--- a/Chromium/CefWrapper.cs
+++ b/Chromium/CefWrapper.cs
@@ -84,7 +84,8 @@ internal class CefWrapper : IDisposable
         this.browser.Paint += this.OnBrowserPaint;
 
         this.framePump = new FramePump(this.browser, this.frameRate.FrameDuration, TimeSpan.FromSeconds(1), this.logger);
-        this.framePump.Start();
+        this.framePump.Start(this.videoPipeline.Options.EnablePacedInvalidation, this.videoPipeline.Options.EnablePumpCadenceAlignment);
+        this.videoPipeline.AttachInvalidator(this.framePump);
         this.videoPipeline.Start();
     }
 

--- a/Launcher/LaunchParameters.cs
+++ b/Launcher/LaunchParameters.cs
@@ -26,7 +26,10 @@ public sealed class LaunchParameters
         bool disableFrameRateLimit,
         bool allowLatencyExpansion,
         bool alignWithCaptureTimestamps,
-        bool enableCadenceTelemetry)
+        bool enableCadenceTelemetry,
+        bool enablePacedInvalidation,
+        bool enableCaptureBackpressure,
+        bool enablePumpCadenceAlignment)
     {
         NdiName = ndiName;
         Port = port;
@@ -43,6 +46,9 @@ public sealed class LaunchParameters
         AllowLatencyExpansion = allowLatencyExpansion;
         AlignWithCaptureTimestamps = alignWithCaptureTimestamps;
         EnableCadenceTelemetry = enableCadenceTelemetry;
+        EnablePacedInvalidation = enablePacedInvalidation;
+        EnableCaptureBackpressure = enableCaptureBackpressure;
+        EnablePumpCadenceAlignment = enablePumpCadenceAlignment;
     }
 
     /// <summary>
@@ -119,6 +125,21 @@ public sealed class LaunchParameters
     /// Gets a value indicating whether telemetry should include capture/output cadence metrics.
     /// </summary>
     public bool EnableCadenceTelemetry { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether paced invalidation should be driven by the paced pipeline.
+    /// </summary>
+    public bool EnablePacedInvalidation { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether Chromium invalidation should pause when the buffer is ahead.
+    /// </summary>
+    public bool EnableCaptureBackpressure { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether cadence alignment telemetry should influence the frame pump.
+    /// </summary>
+    public bool EnablePumpCadenceAlignment { get; }
 
     /// <summary>
     /// Attempts to create a <see cref="LaunchParameters"/> instance from command-line arguments.
@@ -237,6 +258,10 @@ public sealed class LaunchParameters
             enableCadenceTelemetry = true;
         }
 
+        var enablePacedInvalidation = HasFlag("--enable-paced-invalidation");
+        var enableCaptureBackpressure = HasFlag("--enable-capture-backpressure");
+        var enablePumpCadenceAlignment = HasFlag("--enable-pump-cadence-alignment");
+
         int? windowlessFrameRateOverride = null;
         var windowlessRateArg = GetArgValue("--windowless-frame-rate");
         if (windowlessRateArg is not null)
@@ -267,7 +292,10 @@ public sealed class LaunchParameters
             HasFlag("--disable-frame-rate-limit"),
             HasFlag("--allow-latency-expansion"),
             alignWithCaptureTimestamps,
-            enableCadenceTelemetry);
+            enableCadenceTelemetry,
+            enablePacedInvalidation,
+            enableCaptureBackpressure,
+            enablePumpCadenceAlignment);
 
         return true;
     }
@@ -354,6 +382,9 @@ public sealed class LaunchParameters
             settings.DisableFrameRateLimit,
             settings.AllowLatencyExpansion,
             settings.AlignWithCaptureTimestamps,
-            settings.EnableCadenceTelemetry);
+            settings.EnableCadenceTelemetry,
+            settings.EnablePacedInvalidation,
+            settings.EnableCaptureBackpressure,
+            settings.EnablePumpCadenceAlignment);
     }
 }

--- a/Launcher/LauncherForm.cs
+++ b/Launcher/LauncherForm.cs
@@ -18,6 +18,9 @@ public sealed class LauncherForm : Form
     private readonly CheckBox _enableBufferingCheckBox;
     private readonly NumericUpDown _bufferDepthNumericUpDown;
     private readonly CheckBox _allowLatencyExpansionCheckBox;
+    private readonly CheckBox _enablePacedInvalidationCheckBox;
+    private readonly CheckBox _enableCaptureBackpressureCheckBox;
+    private readonly CheckBox _enablePumpCadenceAlignmentCheckBox;
     private readonly NumericUpDown _telemetryNumericUpDown;
     private readonly TextBox _windowlessFrameRateTextBox;
     private readonly CheckBox _disableGpuVsyncCheckBox;
@@ -132,6 +135,30 @@ public sealed class LauncherForm : Form
         };
         AddRow(table, "Latency Expansion", _allowLatencyExpansionCheckBox);
 
+        _enablePacedInvalidationCheckBox = new CheckBox
+        {
+            Text = "Only invalidate Chromium when the paced sender requests",
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+        };
+        AddRow(table, "Paced Invalidation", _enablePacedInvalidationCheckBox);
+
+        _enableCaptureBackpressureCheckBox = new CheckBox
+        {
+            Text = "Pause Chromium invalidation while the buffer is ahead",
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+        };
+        AddRow(table, "Capture Backpressure", _enableCaptureBackpressureCheckBox);
+
+        _enablePumpCadenceAlignmentCheckBox = new CheckBox
+        {
+            Text = "Let cadence telemetry steer the invalidator cadence",
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+        };
+        AddRow(table, "Pump Cadence Alignment", _enablePumpCadenceAlignmentCheckBox);
+
         _telemetryNumericUpDown = new NumericUpDown
         {
             Minimum = 1,
@@ -217,6 +244,7 @@ public sealed class LauncherForm : Form
             var enabled = _enableBufferingCheckBox.Checked;
             _bufferDepthNumericUpDown.Enabled = enabled;
             _allowLatencyExpansionCheckBox.Enabled = enabled;
+            _enableCaptureBackpressureCheckBox.Enabled = enabled;
         };
 
         ApplySettings(initialSettings);
@@ -238,6 +266,10 @@ public sealed class LauncherForm : Form
         _bufferDepthNumericUpDown.Enabled = settings.EnableBuffering;
         _allowLatencyExpansionCheckBox.Checked = settings.AllowLatencyExpansion;
         _allowLatencyExpansionCheckBox.Enabled = settings.EnableBuffering;
+        _enablePacedInvalidationCheckBox.Checked = settings.EnablePacedInvalidation;
+        _enableCaptureBackpressureCheckBox.Checked = settings.EnableCaptureBackpressure;
+        _enableCaptureBackpressureCheckBox.Enabled = settings.EnableBuffering;
+        _enablePumpCadenceAlignmentCheckBox.Checked = settings.EnablePumpCadenceAlignment;
         var telemetryValue = (decimal)Math.Clamp(settings.TelemetryIntervalSeconds, (double)_telemetryNumericUpDown.Minimum, (double)_telemetryNumericUpDown.Maximum);
         _telemetryNumericUpDown.Value = telemetryValue;
         _alignWithCaptureTimestampsCheckBox.Checked = settings.AlignWithCaptureTimestamps;
@@ -289,7 +321,10 @@ public sealed class LauncherForm : Form
                 : _windowlessFrameRateTextBox.Text.Trim(),
             DisableGpuVsync = _disableGpuVsyncCheckBox.Checked,
             DisableFrameRateLimit = _disableFrameRateLimitCheckBox.Checked,
-            AllowLatencyExpansion = _allowLatencyExpansionCheckBox.Checked
+            AllowLatencyExpansion = _allowLatencyExpansionCheckBox.Checked,
+            EnablePacedInvalidation = _enablePacedInvalidationCheckBox.Checked,
+            EnableCaptureBackpressure = _enableCaptureBackpressureCheckBox.Checked,
+            EnablePumpCadenceAlignment = _enablePumpCadenceAlignmentCheckBox.Checked
         };
 
         try

--- a/Launcher/LauncherSettings.cs
+++ b/Launcher/LauncherSettings.cs
@@ -84,4 +84,22 @@ public class LauncherSettings
     /// Gets or sets a value indicating whether to include capture/output cadence metrics in telemetry logs.
     /// </summary>
     public bool EnableCadenceTelemetry { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether paced invalidation is driven by the paced pipeline.
+    /// </summary>
+    public bool EnablePacedInvalidation { get; set; }
+        = false;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether capture invalidation pauses when the buffer is ahead.
+    /// </summary>
+    public bool EnableCaptureBackpressure { get; set; }
+        = false;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether cadence alignment telemetry influences the frame pump.
+    /// </summary>
+    public bool EnablePumpCadenceAlignment { get; set; }
+        = false;
 }

--- a/Program.cs
+++ b/Program.cs
@@ -157,6 +157,9 @@ public class Program
             AllowLatencyExpansion = parameters.AllowLatencyExpansion,
             AlignWithCaptureTimestamps = parameters.AlignWithCaptureTimestamps,
             EnableCadenceTelemetry = parameters.EnableCadenceTelemetry,
+            EnablePacedInvalidation = parameters.EnablePacedInvalidation,
+            EnableCaptureBackpressure = parameters.EnableCaptureBackpressure,
+            EnablePumpCadenceAlignment = parameters.EnablePumpCadenceAlignment,
         };
 
         Log.Information("Ensuring NDI native runtime is available...");

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Parameter|Description
 `--buffer-depth=3`|Enable the paced output buffer with the specified frame capacity. When enabled the sender waits for the queue to hold `depth` frames before transmitting, adding roughly `depth / fps` seconds of intentional latency. Set to `0` (default) to run zero-copy.
 `--enable-output-buffer`|Shortcut to turn on paced buffering with the default depth of 3 frames (≈`3 / fps` seconds of latency once primed).
 `--allow-latency-expansion`|Let the paced buffer keep playing any queued frames during recovery instead of immediately repeating the last frame. This trades temporary extra latency for smoother motion after underruns.
+`--enable-paced-invalidation`|Drive Chromium invalidations directly from the paced sender instead of the pump’s periodic timer. Defaults to legacy periodic invalidation.
+`--enable-capture-backpressure`|Pause Chromium invalidation while the paced buffer backlog exceeds its target depth. Intended for use with the paced buffer.
+`--enable-pump-cadence-alignment`|Allow cadence telemetry to adjust the invalidator cadence in addition to the paced sender’s own alignment logic. Disabled by default.
 `--disable-capture-alignment`|Turns off the paced sender’s capture timestamp alignment (enabled by default). Use `--align-with-capture-timestamps` to explicitly re-enable it for a specific run.
 `--disable-cadence-telemetry`|Suppresses the capture/output cadence jitter metrics in telemetry logs (enabled by default). Use `--enable-cadence-telemetry` to force-enable them when needed.
 `--telemetry-interval=10`|Seconds between video pipeline telemetry log entries. Defaults to 10 seconds.
@@ -43,7 +46,7 @@ Parameter|Description
 `--launcher`|Forces the launcher window to appear even when other parameters are supplied.
 `--no-launcher`|Skips the launcher and honours the supplied command-line arguments only.
 
-When the paced buffer is enabled the pipeline repeats the most recently transmitted frame while warming up or recovering from an underrun so receivers continue to see a stable cadence. Passing `--allow-latency-expansion` switches that recovery into a variable-latency mode that keeps playing any queued frames before falling back to repeats, smoothing out motion at the cost of temporary additional delay. The launcher exposes checkboxes for latency expansion, capture alignment, and cadence telemetry so operators can toggle those behaviours without touching the command line. See [`Docs/paced-output-buffer.md`](Docs/paced-output-buffer.md) for a deeper walkthrough of the priming and telemetry behaviour.
+When the paced buffer is enabled the pipeline repeats the most recently transmitted frame while warming up or recovering from an underrun so receivers continue to see a stable cadence. Passing `--allow-latency-expansion` switches that recovery into a variable-latency mode that keeps playing any queued frames before falling back to repeats, smoothing out motion at the cost of temporary additional delay. The launcher exposes checkboxes for latency expansion, paced invalidation, capture backpressure, capture alignment, cadence telemetry, and pump cadence alignment so operators can toggle those behaviours without touching the command line. See [`Docs/paced-output-buffer.md`](Docs/paced-output-buffer.md) for a deeper walkthrough of the priming and telemetry behaviour.
 
 #### Example Launch
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Parameter|Description
 `--buffer-depth=3`|Enable the paced output buffer with the specified frame capacity. When enabled the sender waits for the queue to hold `depth` frames before transmitting, adding roughly `depth / fps` seconds of intentional latency. Set to `0` (default) to run zero-copy.
 `--enable-output-buffer`|Shortcut to turn on paced buffering with the default depth of 3 frames (≈`3 / fps` seconds of latency once primed).
 `--allow-latency-expansion`|Let the paced buffer keep playing any queued frames during recovery instead of immediately repeating the last frame. This trades temporary extra latency for smoother motion after underruns.
-`--enable-paced-invalidation`|Drive Chromium invalidations directly from the paced sender instead of the pump’s periodic timer. Defaults to legacy periodic invalidation.
-`--enable-capture-backpressure`|Pause Chromium invalidation while the paced buffer backlog exceeds its target depth. Intended for use with the paced buffer.
-`--enable-pump-cadence-alignment`|Allow cadence telemetry to adjust the invalidator cadence in addition to the paced sender’s own alignment logic. Disabled by default.
+`--enable-paced-invalidation`|Drive Chromium invalidations directly from the paced sender so new captures are only requested when the pipeline is ready. Defaults to the legacy periodic invalidator.
+`--enable-capture-backpressure`|Pause Chromium invalidation after sustained positive latency or when the backlog grows beyond the high watermark. Automatically resumes once latency and backlog settle. Intended for use with the paced buffer.
+`--enable-pump-cadence-alignment`|Allow cadence telemetry to adjust the frame pump’s periodic cadence in addition to the paced sender’s own alignment logic. Disabled by default.
 `--disable-capture-alignment`|Turns off the paced sender’s capture timestamp alignment (enabled by default). Use `--align-with-capture-timestamps` to explicitly re-enable it for a specific run.
 `--disable-cadence-telemetry`|Suppresses the capture/output cadence jitter metrics in telemetry logs (enabled by default). Use `--enable-cadence-telemetry` to force-enable them when needed.
 `--telemetry-interval=10`|Seconds between video pipeline telemetry log entries. Defaults to 10 seconds.
@@ -47,6 +47,10 @@ Parameter|Description
 `--no-launcher`|Skips the launcher and honours the supplied command-line arguments only.
 
 When the paced buffer is enabled the pipeline repeats the most recently transmitted frame while warming up or recovering from an underrun so receivers continue to see a stable cadence. Passing `--allow-latency-expansion` switches that recovery into a variable-latency mode that keeps playing any queued frames before falling back to repeats, smoothing out motion at the cost of temporary additional delay. The launcher exposes checkboxes for latency expansion, paced invalidation, capture backpressure, capture alignment, cadence telemetry, and pump cadence alignment so operators can toggle those behaviours without touching the command line. See [`Docs/paced-output-buffer.md`](Docs/paced-output-buffer.md) for a deeper walkthrough of the priming and telemetry behaviour.
+
+### Understanding paced invalidation and backpressure
+
+Paced invalidation lets the video pipeline become the source of truth for when Chromium should render the next frame. Instead of the frame pump invalidating on a fixed cadence, the pipeline issues `RequestInvalidate` calls only after it has handed off the prior frame and is ready for another capture. Enabling capture backpressure layers on safeguards so Chromium pauses after sustained positive capture latency or when the queued backlog breaches a high watermark, preventing oversupply from growing unbounded. The invalidator resumes automatically once both backlog and latency settle, keeping cadence stable without manual intervention.
 
 #### Example Launch
 

--- a/Video/FramePump.cs
+++ b/Video/FramePump.cs
@@ -1,22 +1,35 @@
 using CefSharp;
 using CefSharp.OffScreen;
 using Serilog;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Tractus.HtmlToNdi.Video;
 
 /// <summary>
 /// Periodically invalidates the Chromium browser to trigger paint events.
 /// </summary>
-internal sealed class FramePump : IDisposable
+internal sealed class FramePump : IChromiumInvalidator
 {
+    private static readonly TimeSpan BusyWaitThreshold = TimeSpan.FromMilliseconds(1);
+
     private readonly ChromiumWebBrowser browser;
     private readonly TimeSpan interval;
     private readonly TimeSpan watchdogInterval;
     private readonly CancellationTokenSource cancellation = new();
     private readonly ILogger logger;
+    private readonly object pacedSignalGate = new();
+
+    private TaskCompletionSource<bool> pacedSignal = CreateSignal();
     private Task? pumpTask;
     private Task? watchdogTask;
     private DateTime lastPaint = DateTime.UtcNow;
+    private volatile bool isPaused;
+    private volatile bool usePacedInvalidation;
+    private volatile bool cadenceAlignmentEnabled;
+    private volatile double cadenceDriftFrames;
+    private int invalidateQueued;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FramePump"/> class.
@@ -33,42 +46,164 @@ internal sealed class FramePump : IDisposable
         this.logger = logger;
     }
 
-    /// <summary>
-    /// Starts the frame pump.
-    /// </summary>
-    public void Start()
+    /// <inheritdoc />
+    public void Start(bool usePacedInvalidation, bool enableCadenceAlignment)
     {
         if (pumpTask is not null)
         {
             return;
         }
 
-        pumpTask = Task.Run(async () => await RunPumpAsync(cancellation.Token));
-        watchdogTask = Task.Run(async () => await RunWatchdogAsync(cancellation.Token));
+        this.usePacedInvalidation = usePacedInvalidation;
+        cadenceAlignmentEnabled = enableCadenceAlignment;
+
+        pumpTask = Task.Run(
+            usePacedInvalidation
+                ? () => RunPacedLoopAsync(cancellation.Token)
+                : () => RunPeriodicLoopAsync(cancellation.Token),
+            cancellation.Token);
+
+        watchdogTask = Task.Run(() => RunWatchdogAsync(cancellation.Token), cancellation.Token);
     }
 
-    /// <summary>
-    /// Notifies the frame pump that a paint event has occurred.
-    /// </summary>
+    /// <inheritdoc />
     public void NotifyPaint() => lastPaint = DateTime.UtcNow;
 
-    private async Task RunPumpAsync(CancellationToken token)
+    /// <inheritdoc />
+    public void RequestInvalidate()
     {
-        var timer = new PeriodicTimer(interval);
-        try
+        if (!usePacedInvalidation || cancellation.IsCancellationRequested)
         {
-            while (await timer.WaitForNextTickAsync(token))
+            return;
+        }
+
+        if (Volatile.Read(ref isPaused))
+        {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref invalidateQueued, 1, 0) != 0)
+        {
+            return;
+        }
+
+        SignalPacedLoop();
+    }
+
+    /// <inheritdoc />
+    public void PauseInvalidation()
+    {
+        Volatile.Write(ref isPaused, true);
+        if (usePacedInvalidation)
+        {
+            Interlocked.Exchange(ref invalidateQueued, 0);
+        }
+    }
+
+    /// <inheritdoc />
+    public void ResumeInvalidation()
+    {
+        var wasPaused = Volatile.Read(ref isPaused);
+        Volatile.Write(ref isPaused, false);
+        if (wasPaused)
+        {
+            lastPaint = DateTime.UtcNow;
+        }
+    }
+
+    /// <inheritdoc />
+    public void UpdateCadenceDrift(double deltaFrames)
+    {
+        if (!cadenceAlignmentEnabled)
+        {
+            return;
+        }
+
+        if (double.IsNaN(deltaFrames) || double.IsInfinity(deltaFrames))
+        {
+            deltaFrames = 0d;
+        }
+
+        Volatile.Write(ref cadenceDriftFrames, deltaFrames);
+    }
+
+    private async Task RunPacedLoopAsync(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            Task signalTask;
+            lock (pacedSignalGate)
             {
-                await InvalidateAsync();
+                signalTask = pacedSignal.Task;
             }
+
+            try
+            {
+                await signalTask.WaitAsync(token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+
+            ResetSignal();
+
+            if (token.IsCancellationRequested)
+            {
+                break;
+            }
+
+            var delay = GetPacedDelay();
+            if (delay > TimeSpan.Zero)
+            {
+                try
+                {
+                    await Task.Delay(delay, token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+
+            if (Volatile.Read(ref isPaused))
+            {
+                Interlocked.Exchange(ref invalidateQueued, 0);
+                continue;
+            }
+
+            Interlocked.Exchange(ref invalidateQueued, 0);
+            await InvalidateAsync().ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
+    }
+
+    private async Task RunPeriodicLoopAsync(CancellationToken token)
+    {
+        var clock = Stopwatch.StartNew();
+        var deadline = clock.Elapsed;
+
+        while (!token.IsCancellationRequested)
         {
-            // expected
-        }
-        finally
-        {
-            timer.Dispose();
+            var interval = GetPeriodicInterval();
+            if (interval <= TimeSpan.Zero)
+            {
+                interval = TimeSpan.FromMilliseconds(1);
+            }
+
+            deadline += interval;
+            await WaitUntilAsync(clock, deadline, token).ConfigureAwait(false);
+
+            if (token.IsCancellationRequested)
+            {
+                break;
+            }
+
+            if (Volatile.Read(ref isPaused))
+            {
+                continue;
+            }
+
+            await InvalidateAsync().ConfigureAwait(false);
         }
     }
 
@@ -78,11 +213,38 @@ internal sealed class FramePump : IDisposable
         {
             while (!token.IsCancellationRequested)
             {
-                await Task.Delay(watchdogInterval, token);
-                if (DateTime.UtcNow - lastPaint > watchdogInterval)
+                await Task.Delay(watchdogInterval, token).ConfigureAwait(false);
+                if (token.IsCancellationRequested)
                 {
-                    logger.Debug("FramePump watchdog: re-invalidate Chromium after {Seconds}s", watchdogInterval.TotalSeconds);
-                    await InvalidateAsync();
+                    break;
+                }
+
+                if (Volatile.Read(ref isPaused))
+                {
+                    continue;
+                }
+
+                if (DateTime.UtcNow - lastPaint <= watchdogInterval)
+                {
+                    continue;
+                }
+
+                logger.Debug(
+                    "FramePump watchdog: re-invalidate Chromium after {Seconds}s",
+                    watchdogInterval.TotalSeconds);
+
+                if (usePacedInvalidation)
+                {
+                    if (Interlocked.CompareExchange(ref invalidateQueued, 1, 0) != 0)
+                    {
+                        continue;
+                    }
+                }
+
+                await InvalidateAsync().ConfigureAwait(false);
+                if (usePacedInvalidation)
+                {
+                    Interlocked.Exchange(ref invalidateQueued, 0);
                 }
             }
         }
@@ -104,12 +266,117 @@ internal sealed class FramePump : IDisposable
 
             await Cef.UIThreadTaskFactory.StartNew(() =>
             {
-                host.Invalidate(CefSharp.PaintElementType.View);
-            });
+                if (Volatile.Read(ref isPaused))
+                {
+                    return;
+                }
+
+                host.Invalidate(PaintElementType.View);
+            }).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             logger.Warning(ex, "FramePump failed to invalidate Chromium");
+        }
+    }
+
+    private TimeSpan GetPacedDelay()
+    {
+        if (!cadenceAlignmentEnabled)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var delta = Volatile.Read(ref cadenceDriftFrames);
+        var adjustmentFactor = Math.Clamp(delta * 0.15d, -0.75d, 0.75d);
+        if (adjustmentFactor <= 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var ticks = (long)Math.Clamp(interval.Ticks * adjustmentFactor, 0, interval.Ticks);
+        return ticks <= 0 ? TimeSpan.Zero : TimeSpan.FromTicks(ticks);
+    }
+
+    private TimeSpan GetPeriodicInterval()
+    {
+        if (!cadenceAlignmentEnabled)
+        {
+            return interval;
+        }
+
+        var delta = Volatile.Read(ref cadenceDriftFrames);
+        var adjustmentFactor = Math.Clamp(delta * 0.15d, -0.75d, 0.75d);
+        var adjustedTicks = interval.Ticks + (long)(interval.Ticks * adjustmentFactor);
+        var minimum = TimeSpan.FromMilliseconds(1).Ticks;
+        if (adjustedTicks < minimum)
+        {
+            adjustedTicks = minimum;
+        }
+
+        return TimeSpan.FromTicks(adjustedTicks);
+    }
+
+    private static TaskCompletionSource<bool> CreateSignal()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private void ResetSignal()
+    {
+        lock (pacedSignalGate)
+        {
+            if (pacedSignal.Task.IsCompleted)
+            {
+                pacedSignal = CreateSignal();
+            }
+        }
+    }
+
+    private void SignalPacedLoop()
+    {
+        lock (pacedSignalGate)
+        {
+            if (!pacedSignal.Task.IsCompleted)
+            {
+                pacedSignal.SetResult(true);
+            }
+        }
+    }
+
+    private static async Task WaitUntilAsync(Stopwatch clock, TimeSpan deadline, CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            var remaining = deadline - clock.Elapsed;
+            if (remaining <= TimeSpan.Zero)
+            {
+                return;
+            }
+
+            if (remaining <= BusyWaitThreshold)
+            {
+                while (deadline > clock.Elapsed)
+                {
+                    token.ThrowIfCancellationRequested();
+                    Thread.SpinWait(64);
+                }
+
+                return;
+            }
+
+            var sleep = remaining - BusyWaitThreshold;
+            if (sleep < TimeSpan.FromMilliseconds(1))
+            {
+                sleep = TimeSpan.FromMilliseconds(1);
+            }
+
+            try
+            {
+                await Task.Delay(sleep, token).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                return;
+            }
         }
     }
 

--- a/Video/FramePump.cs
+++ b/Video/FramePump.cs
@@ -258,6 +258,11 @@ internal sealed class FramePump : IChromiumInvalidator
     {
         try
         {
+            if (cancellation.IsCancellationRequested)
+            {
+                return;
+            }
+
             var host = browser.GetBrowserHost();
             if (host is null)
             {
@@ -266,6 +271,11 @@ internal sealed class FramePump : IChromiumInvalidator
 
             await Cef.UIThreadTaskFactory.StartNew(() =>
             {
+                if (cancellation.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 if (Volatile.Read(ref isPaused))
                 {
                     return;
@@ -273,6 +283,10 @@ internal sealed class FramePump : IChromiumInvalidator
 
                 host.Invalidate(PaintElementType.View);
             }).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancellation is expected during shutdown or when invalidation is paused.
         }
         catch (Exception ex)
         {

--- a/Video/FramePump.cs
+++ b/Video/FramePump.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace Tractus.HtmlToNdi.Video;
 
 /// <summary>
-/// Periodically invalidates the Chromium browser to trigger paint events.
+/// Invalidates the Chromium browser to trigger paint events, supporting periodic and paced modes with watchdog coverage.
 /// </summary>
 internal sealed class FramePump : IChromiumInvalidator
 {

--- a/Video/IChromiumInvalidator.cs
+++ b/Video/IChromiumInvalidator.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Tractus.HtmlToNdi.Video;
+
+/// <summary>
+/// Abstraction for scheduling Chromium invalidation work.
+/// </summary>
+internal interface IChromiumInvalidator : IDisposable
+{
+    /// <summary>
+    /// Starts the invalidator.
+    /// </summary>
+    /// <param name="usePacedInvalidation">If <c>true</c>, Chromium invalidations are driven by <see cref="RequestInvalidate"/>; otherwise they follow an internal cadence.</param>
+    /// <param name="enableCadenceAlignment">If <c>true</c>, cadence drift measurements influence the invalidate spacing.</param>
+    void Start(bool usePacedInvalidation, bool enableCadenceAlignment);
+
+    /// <summary>
+    /// Signals that Chromium produced a paint event.
+    /// </summary>
+    void NotifyPaint();
+
+    /// <summary>
+    /// Requests the next Chromium invalidate when paced invalidation is enabled.
+    /// </summary>
+    void RequestInvalidate();
+
+    /// <summary>
+    /// Temporarily suppresses invalidation (periodic and watchdog paths).
+    /// </summary>
+    void PauseInvalidation();
+
+    /// <summary>
+    /// Resumes invalidation after a pause.
+    /// </summary>
+    void ResumeInvalidation();
+
+    /// <summary>
+    /// Updates the cadence drift (in frames) observed by the paced pipeline.
+    /// </summary>
+    /// <param name="deltaFrames">Positive values indicate Chromium is leading the paced output.</param>
+    void UpdateCadenceDrift(double deltaFrames);
+}

--- a/Video/NdiVideoPipeline.cs
+++ b/Video/NdiVideoPipeline.cs
@@ -169,6 +169,7 @@ internal sealed class NdiVideoPipeline : IDisposable
         bufferPrimed = false;
         isWarmingUp = true;
         Interlocked.Exchange(ref capturePauseState, 0);
+        invalidator?.ResumeInvalidation();
         captureRequestPending = options.EnablePacedInvalidation;
     }
 
@@ -623,6 +624,8 @@ internal sealed class NdiVideoPipeline : IDisposable
             outputCadenceTracker.Record(Stopwatch.GetTimestamp());
         }
         EmitTelemetryIfNeeded();
+
+        RequestNextCapture();
     }
 
     private void SendBufferedFrame(NdiVideoFrame frame)
@@ -790,6 +793,7 @@ internal sealed class NdiVideoPipeline : IDisposable
         lastSentFrame = null;
 
         Interlocked.Exchange(ref capturePauseState, 0);
+        invalidator?.ResumeInvalidation();
         captureRequestPending = options.EnablePacedInvalidation;
         RequestNextCapture();
     }

--- a/Video/NdiVideoPipelineOptions.cs
+++ b/Video/NdiVideoPipelineOptions.cs
@@ -37,18 +37,21 @@ internal sealed record NdiVideoPipelineOptions
 
     /// <summary>
     /// Gets or sets a value indicating whether paced invalidation should be driven by the paced sender.
+    /// When enabled the pipeline only requests Chromium invalidations after it finishes processing the prior frame.
     /// </summary>
     public bool EnablePacedInvalidation { get; init; }
         = false;
 
     /// <summary>
     /// Gets or sets a value indicating whether capture invalidation should pause when the buffer is ahead.
+    /// Pauses occur after sustained positive latency or a backlog spike and automatically resume once conditions stabilise.
     /// </summary>
     public bool EnableCaptureBackpressure { get; init; }
         = false;
 
     /// <summary>
     /// Gets or sets a value indicating whether cadence alignment measurements should influence the frame pump.
+    /// When enabled the pump adjusts its periodic interval using drift reported by paced capture telemetry.
     /// </summary>
     public bool EnablePumpCadenceAlignment { get; init; }
         = false;

--- a/Video/NdiVideoPipelineOptions.cs
+++ b/Video/NdiVideoPipelineOptions.cs
@@ -34,4 +34,22 @@ internal sealed record NdiVideoPipelineOptions
     /// Gets or sets a value indicating whether capture/output cadence metrics are logged with telemetry.
     /// </summary>
     public bool EnableCadenceTelemetry { get; init; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether paced invalidation should be driven by the paced sender.
+    /// </summary>
+    public bool EnablePacedInvalidation { get; init; }
+        = false;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether capture invalidation should pause when the buffer is ahead.
+    /// </summary>
+    public bool EnableCaptureBackpressure { get; init; }
+        = false;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether cadence alignment measurements should influence the frame pump.
+    /// </summary>
+    public bool EnablePumpCadenceAlignment { get; init; }
+        = false;
 }


### PR DESCRIPTION
## Summary
- introduce an IChromiumInvalidator abstraction and rework FramePump to support paced invalidation, backpressure pausing, and telemetry-driven cadence alignment
- surface new pacing/backpressure/alignment toggles through pipeline options, CLI flags, launcher UI, and documentation
- coordinate NdiVideoPipeline with the invalidator to schedule Chromium invalidations, apply capture backpressure, and adjust cadence; expand unit tests to cover the new behaviours

## Testing
- `dotnet test` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6901625941508329a720e9bd18477511