### PR TITLE
Request paced invalidation after each capture

### DIFF
--- a/Tests/Tractus.HtmlToNdi.Tests/NdiVideoPipelineTests.cs
+++ b/Tests/Tractus.HtmlToNdi.Tests/NdiVideoPipelineTests.cs
@@ -392,6 +392,102 @@ public class NdiVideoPipelineTests
     }
 
     [Fact]
+    public void BufferedPacedInvalidationDropsUnrequestedFrames()
+    {
+        var sender = new CollectingSender();
+        var options = new NdiVideoPipelineOptions
+        {
+            EnableBuffering = true,
+            BufferDepth = 2,
+            EnablePacedInvalidation = true,
+            TelemetryInterval = TimeSpan.FromDays(1),
+        };
+
+        var pipeline = new NdiVideoPipeline(sender, new FrameRate(60, 1), options, CreateNullLogger());
+        var scheduler = new TestScheduler();
+        pipeline.AttachInvalidationScheduler(scheduler);
+
+        var warmed = SpinWait.SpinUntil(() => scheduler.RequestCount >= 2, TimeSpan.FromMilliseconds(200));
+        Assert.True(warmed);
+
+        var frameSize = 4 * 2 * 2;
+        var buffers = new IntPtr[3];
+
+        try
+        {
+            for (var i = 0; i < buffers.Length; i++)
+            {
+                buffers[i] = Marshal.AllocHGlobal(frameSize);
+                FillBuffer(buffers[i], frameSize, (byte)(0x60 + i));
+                pipeline.HandleFrame(CreateCapturedFrame(buffers[i], 2, 2, 8));
+            }
+
+            Assert.Equal(0, pipeline.PendingInvalidations);
+            Assert.Equal(1, pipeline.SpuriousCaptureCount);
+        }
+        finally
+        {
+            pipeline.Dispose();
+            foreach (var ptr in buffers)
+            {
+                if (ptr != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(ptr);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void BufferedCaptureRequestsFollowUpInvalidation()
+    {
+        var sender = new CollectingSender();
+        var options = new NdiVideoPipelineOptions
+        {
+            EnableBuffering = true,
+            BufferDepth = 3,
+            EnablePacedInvalidation = true,
+            TelemetryInterval = TimeSpan.FromDays(1),
+        };
+
+        var pipeline = new NdiVideoPipeline(sender, new FrameRate(60, 1), options, CreateNullLogger());
+        var scheduler = new TestScheduler();
+        pipeline.AttachInvalidationScheduler(scheduler);
+
+        var warmed = SpinWait.SpinUntil(
+            () => scheduler.RequestCount >= options.BufferDepth,
+            TimeSpan.FromMilliseconds(500));
+        Assert.True(warmed, "Warmup invalidations did not reach expected depth");
+
+        var baseline = scheduler.RequestCount;
+        var frameSize = 4 * 2 * 2;
+        var buffer = Marshal.AllocHGlobal(frameSize);
+
+        try
+        {
+            FillBuffer(buffer, frameSize, 0x33);
+            pipeline.HandleFrame(CreateCapturedFrame(buffer, 2, 2, 8));
+
+            var followUp = SpinWait.SpinUntil(
+                () => scheduler.RequestCount >= baseline + 1,
+                TimeSpan.FromMilliseconds(500));
+
+            Assert.True(
+                followUp,
+                $"Scheduler did not receive follow-up invalidation request. Baseline={baseline}, Actual={scheduler.RequestCount}");
+        }
+        finally
+        {
+            pipeline.Dispose();
+            scheduler.Dispose();
+            if (buffer != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+    }
+
+    [Fact]
     public void LatencyExpansionPlaysQueuedFramesBeforeRepeats()
     {
         var sender = new CollectingSender();
@@ -619,6 +715,48 @@ public class NdiVideoPipelineTests
             Assert.True(count >= options.BufferDepth);
             var slotRequests = count - options.BufferDepth;
             Assert.InRange(slotRequests, framesSent - 1, framesSent + 1);
+        }
+    }
+
+    [Fact]
+    public async Task PendingInvalidationsClampWhenSchedulerStalls()
+    {
+        var sender = new CollectingSender();
+        var scheduler = new TestScheduler();
+        var options = new NdiVideoPipelineOptions
+        {
+            EnableBuffering = true,
+            BufferDepth = 4,
+            TelemetryInterval = TimeSpan.FromDays(1),
+            EnablePacedInvalidation = true
+        };
+
+        scheduler.Pause();
+
+        var pipeline = new NdiVideoPipeline(sender, new FrameRate(60, 1), options, CreateNullLogger());
+        pipeline.AttachInvalidationScheduler(scheduler);
+        pipeline.Start();
+
+        try
+        {
+            var observed = SpinWait.SpinUntil(() => pipeline.PendingInvalidations > 0, TimeSpan.FromMilliseconds(500));
+            Assert.True(observed);
+
+            var limit = options.BufferDepth + 1;
+            Assert.InRange(pipeline.PendingInvalidations, 1, limit);
+
+            var initialRequests = scheduler.RequestCount;
+            await Task.Delay(200);
+            var subsequentRequests = scheduler.RequestCount;
+
+            Assert.Equal(initialRequests, subsequentRequests);
+            Assert.InRange(pipeline.PendingInvalidations, 1, limit);
+        }
+        finally
+        {
+            scheduler.Resume();
+            pipeline.Dispose();
+            scheduler.Dispose();
         }
     }
 


### PR DESCRIPTION
## Summary
- trigger paced Chromium invalidations from each buffered capture instead of the pacing loop so outstanding tickets track actual paints
- guard asynchronous ticket submission against cancellation faults to keep telemetry clean
- add a regression test ensuring buffered captures enqueue a follow-up invalidation request

## Testing
- dotnet test *(fails: `dotnet` CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_6902425123788329aab63e22022dfbdd