### PR TITLE
Reduce busy-wait fallback and surface configuration recipes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,8 +246,8 @@ When adding routes, update **both** this table and `Tractus.HtmlToNdi.http` samp
   honours the capture gate and scheduler pause state so it never overloads Chromium while still preventing the demand counter from
   draining to zero when receivers slow down.
 * Paced output deadlines are driven by a high-resolution waitable timer created with `CreateWaitableTimerEx` / `SetWaitableTimerEx`.
-  When the platform cannot honour those APIs the scheduler falls back to the stopwatch path with short 1 ms sleeps (instead of
-  a pure busy-wait) while logging the downgrade once so it does not peg a CPU when high-res timers are unavailable.
+  When the platform cannot honour those APIs the scheduler falls back to the stopwatch path and busy-waits through the final
+  few milliseconds to preserve deadline precision, logging the downgrade once.
 
 ### Logging & diagnostics (`AppManagement.cs`)
 * `AppManagement.InstanceName` composes `<os>_<arch>_<machinename>` for telemetry or metadata (not currently used elsewhere).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,8 +246,8 @@ When adding routes, update **both** this table and `Tractus.HtmlToNdi.http` samp
   honours the capture gate and scheduler pause state so it never overloads Chromium while still preventing the demand counter from
   draining to zero when receivers slow down.
 * Paced output deadlines are driven by a high-resolution waitable timer created with `CreateWaitableTimerEx` / `SetWaitableTimerEx`.
-  When the platform cannot honour those APIs the scheduler falls back to the stopwatch/busy-wait path while logging the downgrade
-  once.
+  When the platform cannot honour those APIs the scheduler falls back to the stopwatch path with short 1 ms sleeps (instead of
+  a pure busy-wait) while logging the downgrade once so it does not peg a CPU when high-res timers are unavailable.
 
 ### Logging & diagnostics (`AppManagement.cs`)
 * `AppManagement.InstanceName` composes `<os>_<arch>_<machinename>` for telemetry or metadata (not currently used elsewhere).

--- a/Docs/configuration-recipes.md
+++ b/Docs/configuration-recipes.md
@@ -1,0 +1,90 @@
+# Configuration Recipes
+
+This guide provides recommended setting combinations ("recipes") for common use cases. Use these as a starting point and tune based on your specific hardware and network environment.
+
+## 1. Low Latency / Interactive (KVM)
+**Goal:** Minimal delay between mouse/keyboard input and NDI output. Best for remote control or real-time dashboards.
+
+*   **Buffering:** Disabled (`--buffer-depth=0`)
+*   **Paced Invalidation:** Disabled
+*   **Latency Expansion:** N/A
+*   **Cadence Adaptation:** Disabled
+
+**Command Line:**
+```bash
+--buffer-depth=0 --disable-paced-invalidation
+```
+
+**Notes:**
+*   Frames are sent immediately upon capture.
+*   Jitter is determined entirely by Chromium's render timing and system load.
+*   Stutter may occur if the browser load spikes, but latency remains minimal.
+
+---
+
+## 2. Broadcast Standard (Smooth Motion)
+**Goal:** Locked 60fps (or 59.94) output with no visual stutter. Best for tickers, lower thirds, and animated graphics.
+
+*   **Buffering:** Enabled (`--buffer-depth=3`)
+*   **Paced Invalidation:** Enabled (`--enable-paced-invalidation`)
+*   **Cadence Adaptation:** Enabled (`--enable-pump-cadence-adaptation`)
+*   **Latency Expansion:** Disabled (default)
+
+**Command Line:**
+```bash
+--enable-output-buffer --buffer-depth=3 --enable-paced-invalidation --enable-pump-cadence-adaptation
+```
+
+**Notes:**
+*   **Paced Invalidation** ensures Chromium renders exactly when the NDI sender needs a frame, preventing beat-frequency stutter.
+*   **Cadence Adaptation** micro-adjusts the invalidation timing to keep the browser and NDI clocks aligned.
+*   **Latency Expansion** is disabled to ensure that if a stall occurs, the output "jumps" to the latest frame immediately (maintaining strict sync with the live data).
+
+---
+
+## 3. High Resilience / Deep Buffer
+**Goal:** Maximum smoothness even with unreliable rendering or network conditions. Best for signage, complex WebGL, or heavy DOM pages where latency (seconds) is acceptable.
+
+*   **Buffering:** Deep (`--buffer-depth=60` to `300`+)
+*   **Paced Invalidation:** Enabled
+*   **Cadence Adaptation:** Enabled
+*   **Latency Expansion:** Enabled (`--allow-latency-expansion`)
+
+**Command Line:**
+```bash
+--buffer-depth=120 --enable-paced-invalidation --enable-pump-cadence-adaptation --allow-latency-expansion
+```
+
+**Notes:**
+*   **Deep Buffer:** A depth of 120 frames (at 60fps) provides a 2-second safety margin.
+*   **Latency Expansion:** Critical for this mode. If the buffer drains, this flag ensures the remaining frames play out smoothly instead of jumping/trimming. The pipeline will slowly rebuild the buffer over time rather than force-flushing it.
+*   **Hysteresis:** The system automatically uses a 10% hysteresis window for large buffers to prevent rapid oscillation between filling and draining states.
+
+---
+
+## 4. Experimental / High Performance
+**Goal:** Attempt zero-copy capture for reduced CPU usage. Experimental.
+
+*   **Capture Mode:** Compositor (`--enable-compositor-capture`)
+*   **Buffering:** Enabled (`--buffer-depth=3`)
+
+**Command Line:**
+```bash
+--enable-compositor-capture --enable-output-buffer
+```
+
+**Notes:**
+*   Bypasses the standard "paint" loop.
+*   Requires compatible GPU drivers and may fall back if textures are not CPU-accessible.
+*   Does not support `Paced Invalidation` or `Backpressure` as the compositor drives its own cadence.
+
+---
+
+## Summary Table
+
+| Scenario | Buffer Depth | Paced Invalidation | Cadence Adaptation | Latency Expansion |
+| :--- | :--- | :--- | :--- | :--- |
+| **Interactive** | `0` | Off | Off | N/A |
+| **Broadcast** | `3` | **On** | **On** | Off |
+| **Resilience** | `60`+ | **On** | **On** | **On** |
+| **Legacy/Simple** | `0` | Off | Off | N/A |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Launching the executable without command-line parameters now opens a simple laun
 
 If the web page you are loading has a transparent background, NDI will honor that transparency.
 
+See [`Docs/configuration-recipes.md`](Docs/configuration-recipes.md) for ready-made flag combinations tailored to low-latency, broadcast-smooth, deep-buffer, and compositor-driven scenarios.
+
 ## Command Line Parameters
 
 Parameter|Description

--- a/Video/TimingHelpers.cs
+++ b/Video/TimingHelpers.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tractus.HtmlToNdi.Video;
+
+internal static class TimingHelpers
+{
+    private static readonly TimeSpan BusyWaitThreshold = TimeSpan.FromMilliseconds(0.5);
+
+    // Threshold below which we avoid Task.Delay on systems without high-res timers
+    // to prevent oversleeping due to the 15ms system timer quantum. If the coarse
+    // delay falls under this value we fall back to short sleeps so we do not burn
+    // an entire frame interval spinning when a high-resolution timer is absent.
+    private static readonly TimeSpan SpinFallbackThreshold = TimeSpan.FromMilliseconds(10);
+
+    public static void WaitUntil(
+        Stopwatch clock,
+        TimeSpan deadline,
+        CancellationToken token,
+        HighResolutionWaitableTimer? highResolutionTimer)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            var remaining = deadline - clock.Elapsed;
+            if (remaining <= TimeSpan.Zero)
+            {
+                return;
+            }
+
+            if (remaining <= BusyWaitThreshold)
+            {
+                while (deadline > clock.Elapsed)
+                {
+                    token.ThrowIfCancellationRequested();
+                    Thread.SpinWait(64);
+                }
+
+                return;
+            }
+
+            var coarse = remaining - BusyWaitThreshold;
+            if (coarse <= TimeSpan.Zero)
+            {
+                continue;
+            }
+
+            if (highResolutionTimer is not null)
+            {
+                try
+                {
+                    highResolutionTimer.Wait(coarse, token);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+
+                continue;
+            }
+
+            if (coarse < SpinFallbackThreshold)
+            {
+                // Use short sleeps to avoid chewing CPU for long intervals when
+                // the platform timer has coarse resolution. `Task.Delay` can still
+                // overshoot, but spreading the wait across multiple 1ms sleeps is
+                // less disruptive than a tight spin loop.
+                try
+                {
+                    Task.Delay(TimeSpan.FromMilliseconds(1), token).GetAwaiter().GetResult();
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+
+                continue;
+            }
+
+            try
+            {
+                Task.Delay(coarse, token).GetAwaiter().GetResult();
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- soften the stopwatch-based wait helper so low-resolution platforms sleep briefly instead of busy-waiting and burning a core
- link the new configuration recipes guide from the README for easier discovery
- refresh the project briefing to describe the updated timer fallback behaviour

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6924e022533483309789fa3c009f7e60)