### PR TITLE
Resolve pacing variable shadowing and launcher validation

### DIFF
--- a/Launcher/LauncherForm.cs
+++ b/Launcher/LauncherForm.cs
@@ -551,6 +551,14 @@ public sealed class LauncherForm : Form
             frameRateText = "60";
         }
 
+        var pacingModeSelection = _pacingModeComboBox.SelectedItem as string;
+        if (string.IsNullOrWhiteSpace(pacingModeSelection))
+        {
+            MessageBox.Show(this, "Please choose a pacing mode.", "Validation", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            _pacingModeComboBox.Focus();
+            return;
+        }
+
         var settings = new LauncherSettings
         {
             NdiName = ndiName,
@@ -581,7 +589,7 @@ public sealed class LauncherForm : Form
             EnableOutOfProcessRasterization = _enableOutOfProcessRasterizationCheckBox.Checked,
             DisableBackgroundThrottling = _disableBackgroundThrottlingCheckBox.Checked,
             PresetHighPerformance = _presetHighPerformanceCheckBox.Checked,
-            PacingMode = (PacingMode)Enum.Parse(typeof(PacingMode), (string)_pacingModeComboBox.SelectedItem),
+            PacingMode = Enum.Parse<PacingMode>(pacingModeSelection),
             NdiSendAsync = _ndiSendAsyncCheckBox.Checked
         };
 

--- a/Video/NdiVideoPipeline.cs
+++ b/Video/NdiVideoPipeline.cs
@@ -586,8 +586,8 @@ internal sealed class NdiVideoPipeline : IDisposable
             var debt = Volatile.Read(ref latencyError);
             if (debt < 0)
             {
-                var adjustmentTicks = (long)Math.Clamp(debt * SmoothnessRecoveryFactor * frameInterval.Ticks, -maxPacingAdjustmentTicks, 0);
-                return baseline + TimeSpan.FromTicks(adjustmentTicks);
+                var smoothnessAdjustmentTicks = (long)Math.Clamp(debt * SmoothnessRecoveryFactor * frameInterval.Ticks, -maxPacingAdjustmentTicks, 0);
+                return baseline + TimeSpan.FromTicks(smoothnessAdjustmentTicks);
             }
             return baseline;
         }
@@ -1464,11 +1464,11 @@ internal sealed class NdiVideoPipeline : IDisposable
             {
                 ExitWarmup();
             }
-            if (ringBuffer.TryDequeue(out var frame) && frame is not null)
+            if (ringBuffer.TryDequeue(out var smoothnessFrame) && smoothnessFrame is not null)
             {
                 if (latencyError < 0)
                     latencyError += 1;
-                SendBufferedFrame(frame);
+                SendBufferedFrame(smoothnessFrame);
                 return true;
             }
             else


### PR DESCRIPTION
## Summary
- prevent variable shadowing in paced deadline calculation and buffered send paths to satisfy compiler constraints
- validate launcher pacing mode selection before parsing to avoid null enum parsing

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692efa9998788329a0c4e26d82670e5a)