### PR TITLE
Implement RequiresFrameRetention stub in test sender

### DIFF
--- a/Tests/Tractus.HtmlToNdi.Tests/NdiVideoPipelineTests.cs
+++ b/Tests/Tractus.HtmlToNdi.Tests/NdiVideoPipelineTests.cs
@@ -33,6 +33,8 @@ public class NdiVideoPipelineTests
         private readonly object gate = new();
         private readonly List<SentFrame> frames = new();
 
+        public bool RequiresFrameRetention => false;
+
         public IReadOnlyList<SentFrame> Frames
         {
             get


### PR DESCRIPTION
## Summary
- implement the `RequiresFrameRetention` property on the test `CollectingSender` to satisfy the `INdiVideoSender` interface

## Testing
- not run (environment missing `dotnet` SDK)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692efe4d84688329b16fb57c77edc38c)