### PR TITLE
Fix NDI frame rate metadata stability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,9 @@ historical evaluation in `Docs/paced-buffer-pr-evaluation.md`.
   sends those frames directly to `INdiVideoSender` (one frame per pacing slot). With buffering enabled, frames are copied into a
   pooled `FrameRingBuffer<NdiVideoFrame>` once the buffer is primed. `EnsureCpuAccessible` currently drops GPU-only textures,
   so compositor capture falls back silently unless the helper supplies CPU memory. Pacing tracks capture/output cadence, issues
-  invalidation “tickets” to throttle Chromium, and can pause capture entirely when backlog crosses the high-water mark.
+  invalidation “tickets” to throttle Chromium, and can pause capture entirely when backlog crosses the high-water mark. NDI
+  video frames now always advertise the configured frame-rate fraction instead of deriving it from recent capture timestamps so
+  receivers see a stable 30/1 (or 29.97/1.001, etc.) even when Chromium paints slightly fast.
 * **Audio path:** `CustomAudioHandler` allocates one second of float storage, copies each planar channel into its own contiguous
   block inside that buffer, and forwards it to `NDIlib.send_send_audio_v2`. Metadata still reports “interleaved” while the
   payload remains pseudo-planar, so receivers must tolerate the mismatch.

--- a/Video/NdiVideoPipeline.cs
+++ b/Video/NdiVideoPipeline.cs
@@ -18,7 +18,6 @@ internal sealed class NdiVideoPipeline : IDisposable
     private readonly INdiVideoSender sender;
     private readonly FrameRate configuredFrameRate;
     private readonly NdiVideoPipelineOptions options;
-    private readonly FrameTimeAverager timeAverager = new();
     private readonly CancellationTokenSource cancellation = new();
     private readonly FrameRingBuffer<NdiVideoFrame>? ringBuffer;
     private readonly ILogger logger;
@@ -1862,23 +1861,9 @@ internal sealed class NdiVideoPipeline : IDisposable
 
     internal long SpuriousCaptureCount => Interlocked.Read(ref spuriousCaptureCount);
 
-    private (int numerator, int denominator) ResolveFrameRate(DateTime timestamp)
+    private (int numerator, int denominator) ResolveFrameRate(DateTime _)
     {
-        var measured = timeAverager.AddTimestamp(timestamp);
-        if (!measured.HasValue)
-        {
-            return (configuredFrameRate.Numerator, configuredFrameRate.Denominator);
-        }
-
-        try
-        {
-            var measuredRate = FrameRate.FromDouble(measured.Value);
-            return (measuredRate.Numerator, measuredRate.Denominator);
-        }
-        catch
-        {
-            return (configuredFrameRate.Numerator, configuredFrameRate.Denominator);
-        }
+        return (configuredFrameRate.Numerator, configuredFrameRate.Denominator);
     }
 
     private sealed class CadenceTracker


### PR DESCRIPTION
## Summary
- keep NDI video-frame metadata locked to the configured frame-rate fraction instead of deriving it from recent capture cadence
- document the fixed frame-rate metadata behaviour in the project briefing

## Testing
- Not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f10170bc083299225573af51e2c01)